### PR TITLE
Document accountctl CLI workflow

### DIFF
--- a/app/bin/accountctl
+++ b/app/bin/accountctl
@@ -1,14 +1,61 @@
 #!/usr/bin/env python3
-import argparse, getpass, json, os, re, sys, yaml
+"""High verbosity account management CLI for MailAI.
+
+This script is responsible for every manual operation that touches the MailAI
+configuration regarding IMAP accounts.  The user explicitly requested verbose
+inline documentation, therefore every step is annotated to describe *what* the
+code does and *why* it exists.  The core features exposed by the CLI are:
+
+* discovering configuration/secrets directories while allowing overrides via
+  environment variables (the Docker deployment injects those),
+* generating a JSON template describing the mail categories that the AI model
+  manipulates ("important", "newsletter", etc.),
+* ensuring all file writes are atomic to avoid corrupting the YAML/JSON files
+  if the device powers off unexpectedly, and
+* offering five subcommands (``add``, ``update``, ``remove``, ``list`` and
+  ``test``) for day-to-day account administration.
+
+The logic sticks to straightforward data manipulation and favours clarity over
+clever tricks so that operators can easily audit the actions performed by the
+script.
+"""
+
+import argparse
+import getpass
+import json
+import os
+import re
+import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
+
+import yaml
 from imapclient import IMAPClient
 
+# ---------------------------------------------------------------------------
+# Configuration paths
+# ---------------------------------------------------------------------------
+# ``APP_CONFIG`` lets the caller override where the YAML configuration lives.
+# The default matches the location used inside the Docker container.
 CFG_PATH = Path(os.environ.get("APP_CONFIG", "/config/config.yml"))
+
+# Secrets (one file per account containing the IMAP password) live under this
+# directory.  We centralise the path so every function writes to the same
+# location and so the directory can be created lazily when needed.
 SECRETS_DIR = Path("/config/secrets")
+
+# JSON description files describing the MailAI category prompts and mapping are
+# stored here.  ``MAIL_TYPES_DIR`` mirrors the setting used by the main app.
 MAIL_TYPES_DIR = Path(os.environ.get("MAIL_TYPES_DIR", "/config/account_types"))
 
+# ---------------------------------------------------------------------------
+# Generic prompt templates
+# ---------------------------------------------------------------------------
+# Each mail type gets a French description that is embedded into the JSON file.
+# Those prompts are consumed by MailAI to explain to the language model what it
+# should detect.  They also provide documentation for operators reading the
+# files on disk.
 GENERIC_PROMPTS = {
     "important": (
         "Classer dans le dossier Important tout message nécessitant une action rapide, "
@@ -37,28 +84,59 @@ GENERIC_PROMPTS = {
 }
 
 
-def _write_mail_types(path: Path, payload: dict):
+# ---------------------------------------------------------------------------
+# File helpers
+# ---------------------------------------------------------------------------
+
+def _write_mail_types(path: Path, payload: dict) -> None:
+    """Persist the mail-types payload to disk while remaining crash-safe.
+
+    The file is written through a ``.tmp`` suffix and then atomically moved in
+    place with ``os.replace``.  This ensures there is never a partially written
+    JSON file if the Raspberry Pi loses power mid-operation.
+    """
+
+    # Update a metadata field so operators know when the file was generated.
     payload["updated_at"] = datetime.utcnow().isoformat()
+
+    # Guarantee the destination directory exists (``mkdir`` is idempotent).
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
+
+    # Dump the JSON in UTF-8 while keeping accents readable (``ensure_ascii``).
     with open(tmp, "w", encoding="utf-8") as fh:
         json.dump(payload, fh, indent=2, ensure_ascii=False)
+
+    # ``os.replace`` performs an atomic rename on POSIX systems.
     os.replace(tmp, path)
 
 
-def _sync_targets(payload: dict, mapping_targets: dict, spam_folder: str, quarantine_folder: str):
+def _sync_targets(payload: dict, mapping_targets: dict, spam_folder: str, quarantine_folder: str) -> None:
+    """Adjust target folders for each mail type using the provided mapping."""
+
     for entry in payload.get("types", []):
         key = entry.get("key")
+
+        # ``spam`` and ``quarantine`` are forced to use the dedicated folders so
+        # the model cannot accidentally move them elsewhere.
         if key == "spam" and spam_folder:
             entry["target_folder"] = spam_folder
         elif key == "quarantine" and quarantine_folder:
             entry["target_folder"] = quarantine_folder
+
+        # Optional targets (important/newsletter/…) rely on the mapping if the
+        # caller provided one.
         elif key in mapping_targets and mapping_targets.get(key):
             entry["target_folder"] = mapping_targets[key]
-        elif key == "factures":
-            # Default invoices to the project folder if nothing else is set
-            if not entry.get("target_folder"):
-                entry["target_folder"] = mapping_targets.get("projet") or quarantine_folder or spam_folder
+
+        # Invoices default to the "projet" folder, otherwise fall back to
+        # quarantine or spam so that documents are not left unclassified.
+        elif key == "factures" and not entry.get("target_folder"):
+            entry["target_folder"] = (
+                mapping_targets.get("projet")
+                or quarantine_folder
+                or spam_folder
+            )
 
 
 def ensure_mail_types(
@@ -68,6 +146,14 @@ def ensure_mail_types(
     quarantine_folder: str,
     existing_path: Optional[str] = None,
 ) -> Path:
+    """Create or merge the JSON file driving MailAI category mappings.
+
+    When ``existing_path`` is provided the function loads it and appends any
+    missing defaults so that upgrades remain backwards compatible.  Otherwise a
+    fresh payload is generated using :data:`GENERIC_PROMPTS`.
+    """
+
+    # ``base_payload`` contains every known mail type with a sensible default.
     base_payload = {
         "account": name,
         "version": 1,
@@ -117,15 +203,16 @@ def ensure_mail_types(
         ],
     }
 
+    # Either reuse the existing JSON (update flow) or create a new file next to
+    # the other account definitions.
     path = Path(existing_path) if existing_path else MAIL_TYPES_DIR / f"{name}.json"
     if path.exists():
         with open(path, "r", encoding="utf-8") as fh:
             payload = json.load(fh)
-        # Merge missing defaults without overwriting user customisations
         existing_keys = {t.get("key") for t in payload.get("types", [])}
-        for t in base_payload["types"]:
-            if t["key"] not in existing_keys:
-                payload.setdefault("types", []).append(t)
+        for entry in base_payload["types"]:
+            if entry["key"] not in existing_keys:
+                payload.setdefault("types", []).append(entry)
     else:
         payload = base_payload
 
@@ -133,124 +220,189 @@ def ensure_mail_types(
     _write_mail_types(path, payload)
     return path
 
-def load_cfg():
-    if not CFG_PATH.exists():
-        print(f"Config not found: {CFG_PATH}", file=sys.stderr); sys.exit(2)
-    with open(CFG_PATH,"r") as f: return yaml.safe_load(f)
 
-def save_cfg(cfg):
+# ---------------------------------------------------------------------------
+# Configuration helpers
+# ---------------------------------------------------------------------------
+
+def load_cfg():
+    """Read ``config.yml`` from disk and abort if the file is missing."""
+
+    if not CFG_PATH.exists():
+        print(f"Config not found: {CFG_PATH}", file=sys.stderr)
+        sys.exit(2)
+
+    with open(CFG_PATH, "r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def save_cfg(cfg) -> None:
+    """Write ``config.yml`` atomically to prevent corruption."""
+
     tmp = CFG_PATH.with_suffix(".tmp")
-    with open(tmp,"w") as f: yaml.safe_dump(cfg, f, sort_keys=False, allow_unicode=True)
+    with open(tmp, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(cfg, fh, sort_keys=False, allow_unicode=True)
     os.replace(tmp, CFG_PATH)
 
-def norm_name(name:str)->str: return re.sub(r"[^a-zA-Z0-9_-]+","", name.strip())
 
-def find_acc(cfg, name):
-    for i,a in enumerate(cfg.get("accounts",[])):
-        if a.get("name")==name: return i,a
-    return None,None
+def norm_name(name: str) -> str:
+    """Sanitise the account name so it is safe for filenames and YAML keys."""
+
+    return re.sub(r"[^a-zA-Z0-9_-]+", "", name.strip())
+
+
+def find_acc(cfg, name: str) -> Tuple[Optional[int], Optional[dict]]:
+    """Locate an account inside the configuration and return its index."""
+
+    for idx, account in enumerate(cfg.get("accounts", [])):
+        if account.get("name") == name:
+            return idx, account
+    return None, None
+
 
 def test_imap(host, port, ssl, user, pwd):
+    """Check IMAP credentials by logging in and selecting the INBOX."""
+
     with IMAPClient(host, port=int(port), ssl=bool(ssl)) as srv:
-        srv.login(user, pwd); srv.select_folder("INBOX", readonly=True)
+        srv.login(user, pwd)
+        srv.select_folder("INBOX", readonly=True)
     return True, None
 
-def _to_str(x):
-    if isinstance(x, bytes):
-        try: return x.decode('utf-8', 'ignore')
-        except: return x.decode('latin-1', 'ignore')
-    return x
+
+# ---------------------------------------------------------------------------
+# IMAP folder helpers
+# ---------------------------------------------------------------------------
+
+def _to_str(value):
+    """Best-effort decoding helper for IMAP folder names."""
+
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8", "ignore")
+        except Exception:
+            return value.decode("latin-1", "ignore")
+    return value
+
 
 def detect_mailbox_style(srv):
+    """Inspect the IMAP hierarchy to discover delimiters and namespaces."""
+
     folders = srv.list_folders()
-    delim_raw = next((d for _f,d,_n in folders if d), '/')
-    delim = _to_str(delim_raw) or '/'
-    existing = {_to_str(name) for _f,_d,name in folders}
+    delim_raw = next((delim for _flags, delim, _name in folders if delim), "/")
+    delim = _to_str(delim_raw) or "/"
+    existing = {_to_str(name) for _flags, _delim, name in folders}
     has_inbox_ns = any(name.upper().startswith(f"INBOX{delim}") for name in existing)
     return delim, has_inbox_ns, existing
 
+
 def normalize_folder(user_str, delim, has_inbox_ns):
-    s = (user_str or "").strip()
-    if not s: return s
-    up = s.upper()
-    if up.startswith("INBOX/") or up.startswith("INBOX."):
-        s = s.replace("/", delim).replace(".", delim)
-        return s
-    s = s.replace("/", delim).replace(".", delim)
+    """Convert user-provided folder names to the server convention."""
+
+    name = (user_str or "").strip()
+    if not name:
+        return name
+
+    upper = name.upper()
+    if upper.startswith("INBOX/") or upper.startswith("INBOX."):
+        return name.replace("/", delim).replace(".", delim)
+
+    name = name.replace("/", delim).replace(".", delim)
     if has_inbox_ns:
-        s = f"INBOX{delim}{s}"
-    return s
+        name = f"INBOX{delim}{name}"
+    return name
+
 
 def ensure_folders(srv, targets, existing):
-    created=[]
+    """Create the IMAP folders that do not exist yet and report them."""
+
+    created = []
     for box in targets:
-        if not box: continue
+        if not box:
+            continue
         if box not in existing:
             try:
                 srv.create_folder(box)
                 created.append(box)
                 existing.add(box)
-            except Exception as e:
-                print(f"[WARN] create {box}: {e}", file=sys.stderr)
+            except Exception as exc:
+                print(f"[WARN] create {box}: {exc}", file=sys.stderr)
     return created
 
+
+# ---------------------------------------------------------------------------
+# CLI handlers
+# ---------------------------------------------------------------------------
+
 def add_account(args):
+    """Handle ``accountctl add``."""
+
     if not args.host:
-        print("[ERROR] --host is required (no default).", file=sys.stderr); sys.exit(2)
+        print("[ERROR] --host is required (no default).", file=sys.stderr)
+        sys.exit(2)
 
     cfg = load_cfg()
-    accs = cfg.setdefault("accounts", [])
+    accounts = cfg.setdefault("accounts", [])
     name = norm_name(args.name)
-    if not name: print("Invalid account name", file=sys.stderr); sys.exit(2)
-    if any(a.get("name")==name for a in accs):
-        print(f"Account '{name}' already exists.", file=sys.stderr); sys.exit(2)
+    if not name:
+        print("Invalid account name", file=sys.stderr)
+        sys.exit(2)
+    if any(acc.get("name") == name for acc in accounts):
+        print(f"Account '{name}' already exists.", file=sys.stderr)
+        sys.exit(2)
 
     SECRETS_DIR.mkdir(parents=True, exist_ok=True)
     secret_file = SECRETS_DIR / f"{name}.pass"
 
     user = args.user or input("IMAP username (email): ").strip()
-    pwd  = args.password or getpass.getpass("IMAP password: ")
+    password = args.password or getpass.getpass("IMAP password: ")
 
     try:
         with IMAPClient(args.host, port=int(args.port), ssl=not args.no_ssl) as srv:
-            srv.login(user, pwd)
+            srv.login(user, password)
             delim, has_inbox_ns, existing = detect_mailbox_style(srv)
 
-            spam_f        = args.spam        or "Junk"
-            important_f   = args.important   or "Important"
-            newsletter_f  = args.newsletter  or "Promotions"
-            projet_f      = args.projet      or "Projects"
-            basse_f       = args.basse       or "SocialNetwork"
-            quarantine_f  = args.quarantine  or "AI/A-REVIEW"
+            # Provide defaults for the various folders but allow CLI overrides.
+            spam_f = args.spam or "Junk"
+            important_f = args.important or "Important"
+            newsletter_f = args.newsletter or "Promotions"
+            projet_f = args.projet or "Projects"
+            basse_f = args.basse or "SocialNetwork"
+            quarantine_f = args.quarantine or "AI/A-REVIEW"
 
-            spam_f_n        = normalize_folder(spam_f,        delim, has_inbox_ns)
-            important_f_n   = normalize_folder(important_f,   delim, has_inbox_ns)
-            newsletter_f_n  = normalize_folder(newsletter_f,  delim, has_inbox_ns)
-            projet_f_n      = normalize_folder(projet_f,      delim, has_inbox_ns)
-            basse_f_n       = normalize_folder(basse_f,       delim, has_inbox_ns)
-            quarantine_f_n  = normalize_folder(quarantine_f,  delim, has_inbox_ns)
+            spam_f_n = normalize_folder(spam_f, delim, has_inbox_ns)
+            important_f_n = normalize_folder(important_f, delim, has_inbox_ns)
+            newsletter_f_n = normalize_folder(newsletter_f, delim, has_inbox_ns)
+            projet_f_n = normalize_folder(projet_f, delim, has_inbox_ns)
+            basse_f_n = normalize_folder(basse_f, delim, has_inbox_ns)
+            quarantine_f_n = normalize_folder(quarantine_f, delim, has_inbox_ns)
 
             if not args.no_create_folders:
-                to_create = [x for x in [spam_f_n, important_f_n, newsletter_f_n, projet_f_n, basse_f_n, quarantine_f_n] if x]
+                to_create = [
+                    folder
+                    for folder in [spam_f_n, important_f_n, newsletter_f_n, projet_f_n, basse_f_n, quarantine_f_n]
+                    if folder
+                ]
                 created = ensure_folders(srv, to_create, existing)
                 if created:
                     print("[OK] Created folders:", ", ".join(created))
 
             mapping_targets = {
-                "important":  important_f_n,
+                "important": important_f_n,
                 "newsletter": newsletter_f_n,
-                "projet":     projet_f_n,
-                "basse":      basse_f_n,
+                "projet": projet_f_n,
+                "basse": basse_f_n,
                 "quarantine": quarantine_f_n,
             }
-    except Exception as e:
-        print(f"[ERROR] IMAP connection or folder setup: {e}", file=sys.stderr); sys.exit(1)
+    except Exception as exc:
+        print(f"[ERROR] IMAP connection or folder setup: {exc}", file=sys.stderr)
+        sys.exit(1)
 
-    secret_file.write_text(pwd); os.chmod(secret_file, 0o600)
+    secret_file.write_text(password)
+    os.chmod(secret_file, 0o600)
 
     types_path = ensure_mail_types(name, mapping_targets, spam_f_n, quarantine_f_n)
 
-    new_acc = {
+    new_account = {
         "name": name,
         "imap": {
             "host": args.host,
@@ -265,13 +417,15 @@ def add_account(args):
         },
         "folders": {
             "inbox": "INBOX",
-            "spam":  spam_f_n,
-            "targets": mapping_targets
+            "spam": spam_f_n,
+            "targets": mapping_targets,
         },
         "mail_types_config": str(types_path),
-        "rules": []
+        "rules": [],
     }
-    accs.append(new_acc); save_cfg(cfg)
+
+    accounts.append(new_account)
+    save_cfg(cfg)
 
     print(f"[OK] Account '{name}' added ({user}@{args.host}). Secret: {secret_file}")
     print("Folders mapping (normalized):")
@@ -282,104 +436,165 @@ def add_account(args):
     print(f"  Social/Low  -> {mapping_targets['basse']}")
     print(f"  Quarantine  -> {mapping_targets['quarantine']}")
 
-def update_account(args):
-    cfg = load_cfg(); idx, acc = find_acc(cfg, args.name)
-    if acc is None:
-        print(f"Account '{args.name}' not found.", file=sys.stderr); sys.exit(2)
 
-    if args.user:  acc["imap"]["user"] = args.user
-    if args.host:  acc["imap"]["host"] = args.host
-    if args.port:  acc["imap"]["port"] = int(args.port)
-    if args.no_ssl is True:   acc["imap"]["ssl"] = False
-    if args.ssl is True:      acc["imap"]["ssl"] = True
+def update_account(args):
+    """Handle ``accountctl update``."""
+
+    cfg = load_cfg()
+    idx, account = find_acc(cfg, args.name)
+    if account is None:
+        print(f"Account '{args.name}' not found.", file=sys.stderr)
+        sys.exit(2)
+
+    if args.user:
+        account["imap"]["user"] = args.user
+    if args.host:
+        account["imap"]["host"] = args.host
+    if args.port:
+        account["imap"]["port"] = int(args.port)
+    if args.no_ssl is True:
+        account["imap"]["ssl"] = False
+    if args.ssl is True:
+        account["imap"]["ssl"] = True
 
     if any([args.spam, args.important, args.newsletter, args.projet, args.basse, args.quarantine]):
-        pwd = Path(acc["imap"]["password_file"]).read_text().strip()
-        with IMAPClient(acc["imap"]["host"], port=acc["imap"]["port"], ssl=acc["imap"].get("ssl",True)) as srv:
-            srv.login(acc["imap"]["user"], pwd)
+        password = Path(account["imap"]["password_file"]).read_text().strip()
+        with IMAPClient(account["imap"]["host"], port=account["imap"]["port"], ssl=account["imap"].get("ssl", True)) as srv:
+            srv.login(account["imap"]["user"], password)
             delim, has_inbox_ns, existing = detect_mailbox_style(srv)
-            def n(s): return normalize_folder(s, delim, has_inbox_ns) if s else None
-            if args.spam:       acc["folders"]["spam"] = n(args.spam)
-            t = acc["folders"].setdefault("targets", {})
-            if args.important:  t["important"]   = n(args.important)
-            if args.newsletter: t["newsletter"]  = n(args.newsletter)
-            if args.projet:     t["projet"]      = n(args.projet)
-            if args.basse:      t["basse"]       = n(args.basse)
-            if args.quarantine: t["quarantine"]  = n(args.quarantine)
-            to_create = [acc["folders"].get("spam")] + list(t.values())
-            to_create = [x for x in to_create if x]
+
+            def normalise(value):
+                return normalize_folder(value, delim, has_inbox_ns) if value else None
+
+            if args.spam:
+                account["folders"]["spam"] = normalise(args.spam)
+            targets = account.get("folders", {}).setdefault("targets", {})
+            if args.important:
+                targets["important"] = normalise(args.important)
+            if args.newsletter:
+                targets["newsletter"] = normalise(args.newsletter)
+            if args.projet:
+                targets["projet"] = normalise(args.projet)
+            if args.basse:
+                targets["basse"] = normalise(args.basse)
+            if args.quarantine:
+                targets["quarantine"] = normalise(args.quarantine)
+
+            to_create = [account["folders"].get("spam")] + list(targets.values())
+            to_create = [folder for folder in to_create if folder]
             if not args.no_create_folders:
                 created = ensure_folders(srv, to_create, existing)
                 if created:
                     print("[OK] Created folders:", ", ".join(created))
 
-    acc.setdefault("mode", {})
-    if args.auto_move: acc["mode"]["auto_move"] = True
-    if args.no_move:   acc["mode"]["auto_move"] = False
-    if args.auto_spam: acc["mode"]["auto_spam"] = True
-    if args.no_spam:   acc["mode"]["auto_spam"] = False
+    account.setdefault("mode", {})
+    if args.auto_move:
+        account["mode"]["auto_move"] = True
+    if args.no_move:
+        account["mode"]["auto_move"] = False
+    if args.auto_spam:
+        account["mode"]["auto_spam"] = True
+    if args.no_spam:
+        account["mode"]["auto_spam"] = False
 
-    targets = acc.get("folders", {}).setdefault("targets", {})
-    spam_folder = acc.get("folders", {}).get("spam")
+    targets = account.get("folders", {}).setdefault("targets", {})
+    spam_folder = account.get("folders", {}).get("spam")
     quarantine_folder = targets.get("quarantine")
-    types_path = ensure_mail_types(args.name, targets, spam_folder, quarantine_folder, acc.get("mail_types_config"))
-    acc["mail_types_config"] = str(types_path)
+    types_path = ensure_mail_types(args.name, targets, spam_folder, quarantine_folder, account.get("mail_types_config"))
+    account["mail_types_config"] = str(types_path)
 
     if args.rotate_password:
-        secret_path = Path(acc["imap"]["password_file"])
+        secret_path = Path(account["imap"]["password_file"])
         SECRETS_DIR.mkdir(parents=True, exist_ok=True)
         if not secret_path.parent.exists():
             secret_path = SECRETS_DIR / f"{args.name}.pass"
-            acc["imap"]["password_file"] = str(secret_path)
-        pwd = getpass.getpass("New IMAP password: ")
-        test_imap(acc["imap"]["host"], acc["imap"]["port"], acc["imap"]["ssl"], acc["imap"]["user"], pwd)
-        secret_path.write_text(pwd); os.chmod(secret_path, 0o600)
+            account["imap"]["password_file"] = str(secret_path)
+        new_password = getpass.getpass("New IMAP password: ")
+        test_imap(account["imap"]["host"], account["imap"]["port"], account["imap"]["ssl"], account["imap"]["user"], new_password)
+        secret_path.write_text(new_password)
+        os.chmod(secret_path, 0o600)
         print("[OK] Password updated.")
 
-    save_cfg(cfg); print(f"[OK] Account '{args.name}' updated.")
+    save_cfg(cfg)
+    print(f"[OK] Account '{args.name}' updated.")
+
 
 def remove_account(args):
-    cfg = load_cfg(); idx, acc = find_acc(cfg, args.name)
-    if acc is None:
-        print(f"Account '{args.name}' not found.", file=sys.stderr); sys.exit(2)
-    secret = acc["imap"].get("password_file")
-    types_cfg = acc.get("mail_types_config")
-    del cfg["accounts"][idx]; save_cfg(cfg)
+    """Handle ``accountctl remove``."""
+
+    cfg = load_cfg()
+    idx, account = find_acc(cfg, args.name)
+    if account is None:
+        print(f"Account '{args.name}' not found.", file=sys.stderr)
+        sys.exit(2)
+
+    secret = account["imap"].get("password_file")
+    types_cfg = account.get("mail_types_config")
+    del cfg["accounts"][idx]
+    save_cfg(cfg)
+
     if args.delete_secret and secret:
-        try: Path(secret).unlink(); print(f"[OK] Secret removed: {secret}")
-        except FileNotFoundError: pass
+        try:
+            Path(secret).unlink()
+            print(f"[OK] Secret removed: {secret}")
+        except FileNotFoundError:
+            pass
+
     if types_cfg:
         try:
             Path(types_cfg).unlink()
             print(f"[OK] Mail types config removed: {types_cfg}")
         except FileNotFoundError:
             pass
+
     print(f"[OK] Account '{args.name}' removed.")
 
+
 def list_accounts(_args):
-    cfg = load_cfg(); accs = cfg.get("accounts",[])
-    if not accs: print("(no accounts)"); return
-    for a in accs:
-        t = a.get("folders",{}).get("targets",{})
-        print(f"- {a['name']}: {a['imap']['user']} @ {a['imap']['host']}:{a['imap']['port']} "
-              f"ssl={a['imap'].get('ssl',True)} auto_move={a.get('mode',{}).get('auto_move',False)} "
-              f"auto_spam={a.get('mode',{}).get('auto_spam',False)} "
-              f"[Spam={a['folders'].get('spam')}, Important={t.get('important')}, "
-              f"Promotions={t.get('newsletter')}, Social={t.get('basse')}, "
-              f"Projects={t.get('projet')}, Quarantine={t.get('quarantine')}]")
-        if a.get("mail_types_config"):
-            print(f"    mail_types_config={a['mail_types_config']}")
+    """Handle ``accountctl list``."""
+
+    cfg = load_cfg()
+    accounts = cfg.get("accounts", [])
+    if not accounts:
+        print("(no accounts)")
+        return
+
+    for account in accounts:
+        targets = account.get("folders", {}).get("targets", {})
+        print(
+            f"- {account['name']}: {account['imap']['user']} @ {account['imap']['host']}:{account['imap']['port']} "
+            f"ssl={account['imap'].get('ssl', True)} auto_move={account.get('mode', {}).get('auto_move', False)} "
+            f"auto_spam={account.get('mode', {}).get('auto_spam', False)} "
+            f"[Spam={account['folders'].get('spam')}, Important={targets.get('important')}, "
+            f"Promotions={targets.get('newsletter')}, Social={targets.get('basse')}, "
+            f"Projects={targets.get('projet')}, Quarantine={targets.get('quarantine')}]"
+        )
+        if account.get("mail_types_config"):
+            print(f"    mail_types_config={account['mail_types_config']}")
+
 
 def test_account(args):
-    cfg = load_cfg(); _idx, acc = find_acc(cfg, args.name)
-    if acc is None:
-        print(f"Account '{args.name}' not found.", file=sys.stderr); sys.exit(2)
-    user=acc["imap"]["user"]; host=acc["imap"]["host"]; port=acc["imap"]["port"]; ssl=acc["imap"].get("ssl",True)
-    pwd = Path(acc["imap"]["password_file"]).read_text().strip()
-    test_imap(host, port, ssl, user, pwd)
+    """Handle ``accountctl test``."""
+
+    cfg = load_cfg()
+    _idx, account = find_acc(cfg, args.name)
+    if account is None:
+        print(f"Account '{args.name}' not found.", file=sys.stderr)
+        sys.exit(2)
+
+    user = account["imap"]["user"]
+    host = account["imap"]["host"]
+    port = account["imap"]["port"]
+    ssl = account["imap"].get("ssl", True)
+    password = Path(account["imap"]["password_file"]).read_text().strip()
+
+    test_imap(host, port, ssl, user, password)
     print(f"[OK] IMAP connection for '{args.name}' succeeded.")
 
+
 def main():
+    """Parse CLI arguments and dispatch to the appropriate handler."""
+
     ap = argparse.ArgumentParser(description="Account management for RPi-MailAI")
     sub = ap.add_subparsers(dest="cmd", required=True)
 
@@ -403,14 +618,23 @@ def main():
 
     ap_up = sub.add_parser("update", help="Update an account or folder mapping")
     ap_up.add_argument("name")
-    ap_up.add_argument("--user"); ap_up.add_argument("--host"); ap_up.add_argument("--port")
-    sslgrp = ap_up.add_mutually_exclusive_group()
-    sslgrp.add_argument("--ssl", action="store_true"); sslgrp.add_argument("--no-ssl", action="store_true")
-    ap_up.add_argument("--spam"); ap_up.add_argument("--important"); ap_up.add_argument("--newsletter")
-    ap_up.add_argument("--projet"); ap_up.add_argument("--basse"); ap_up.add_argument("--quarantine")
+    ap_up.add_argument("--user")
+    ap_up.add_argument("--host")
+    ap_up.add_argument("--port")
+    ssl_group = ap_up.add_mutually_exclusive_group()
+    ssl_group.add_argument("--ssl", action="store_true")
+    ssl_group.add_argument("--no-ssl", action="store_true")
+    ap_up.add_argument("--spam")
+    ap_up.add_argument("--important")
+    ap_up.add_argument("--newsletter")
+    ap_up.add_argument("--projet")
+    ap_up.add_argument("--basse")
+    ap_up.add_argument("--quarantine")
     ap_up.add_argument("--no-create-folders", action="store_true", help="Do not auto-create missing folders")
-    ap_up.add_argument("--auto-move", action="store_true"); ap_up.add_argument("--no-move", action="store_true")
-    ap_up.add_argument("--auto-spam", action="store_true"); ap_up.add_argument("--no-spam", action="store_true")
+    ap_up.add_argument("--auto-move", action="store_true")
+    ap_up.add_argument("--no-move", action="store_true")
+    ap_up.add_argument("--auto-spam", action="store_true")
+    ap_up.add_argument("--no-spam", action="store_true")
     ap_up.add_argument("--rotate-password", action="store_true", help="Change password (tests live)")
     ap_up.set_defaults(func=update_account)
 
@@ -419,10 +643,16 @@ def main():
     ap_rm.add_argument("--delete-secret", action="store_true", help="Also delete stored secret file")
     ap_rm.set_defaults(func=remove_account)
 
-    ap_ls = sub.add_parser("list", help="List accounts"); ap_ls.set_defaults(func=list_accounts)
+    ap_ls = sub.add_parser("list", help="List accounts")
+    ap_ls.set_defaults(func=list_accounts)
+
     ap_test = sub.add_parser("test", help="Test IMAP connection for an account")
-    ap_test.add_argument("name"); ap_test.set_defaults(func=test_account)
+    ap_test.add_argument("name")
+    ap_test.set_defaults(func=test_account)
 
-    args = ap.parse_args(); args.func(args)
+    args = ap.parse_args()
+    args.func(args)
 
-if __name__ == "__main__": main()
+
+if __name__ == "__main__":
+    main()

--- a/app/mailai.py
+++ b/app/mailai.py
@@ -1,4 +1,22 @@
 #!/usr/bin/env python3
+"""MailAI: automatisation de la classification des emails.
+
+Ce script regroupe l'ensemble de la chaîne de traitement de l'application :
+
+* Initialisation/maintenance de la base SQLite qui stocke les emails vus et
+  leurs décisions associées.
+* Synchronisation des boîtes IMAP pour récupérer le contenu brut des
+  messages et garder une trace de leur dernière position côté serveur.
+* Entraînement et utilisation d'un modèle de classification (Sentence
+  Transformers + régression logistique) pour suggérer ou appliquer des règles
+  de tri automatique.
+* Outils de monitoring (statistiques) et de scheduling (boucle continue).
+
+L'objectif de cette passe de documentation est de rendre le flot de
+traitement explicitement lisible : chaque étape est abondamment commentée pour
+faciliter l'onboarding ou le debug futur.
+"""
+
 import json
 import os, sys, time, yaml, sqlite3, email, re, random
 from collections import defaultdict
@@ -17,28 +35,57 @@ DATA_DIR = Path(os.environ.get("DATA_DIR", "/data"))
 MAIL_TYPES_DIR = Path(os.environ.get("MAIL_TYPES_DIR", "/config/account_types"))
 DB_PATH = DATA_DIR / "db" / "mailai.sqlite"
 MODEL_DIR = DATA_DIR / "models"
+
+# L'entraînement et les prédictions nécessitent la présence d'un dossier pour
+# stocker les artefacts (modèles, encodeur). On crée donc le dossier dès le
+# chargement du module pour éviter les races lors d'exécutions parallèles.
 MODEL_DIR.mkdir(parents=True, exist_ok=True)
 
 # === HELPERS ===
 def load_cfg():
+    """Charge la configuration principale de l'application.
+
+    La configuration YAML décrit entre autres les comptes IMAP à suivre, les
+    paramètres du modèle et la planification.
+    """
+
+    # On s'assure que le fichier est présent avant de tenter de le parser :
+    # sans configuration l'application ne peut pas fonctionner.
     if not CFG_PATH.exists():
         print(f"[ERROR] config missing: {CFG_PATH}", file=sys.stderr)
         sys.exit(2)
-    with open(CFG_PATH,"r") as f: return yaml.safe_load(f)
+
+    # Chargement brut du YAML -> dictionnaire Python.
+    with open(CFG_PATH, "r") as f:
+        return yaml.safe_load(f)
 
 def db_init():
+    """Prépare la base SQLite et effectue les migrations minimales.
+
+    On crée les tables nécessaires si elles n'existent pas encore puis on
+    applique quelques migrations simples (ajout de colonnes). La fonction
+    renvoie un handle `sqlite3.Connection` réutilisable par l'appelant.
+    """
+
+    # Création du répertoire de travail si besoin avant d'ouvrir la base.
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
-    c.execute("""CREATE TABLE IF NOT EXISTS mails (
+
+    # Table principale : un enregistrement par email unique (compte + Message-ID).
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS mails (
         id INTEGER PRIMARY KEY,
         account TEXT, msgid TEXT, subject TEXT, body TEXT,
         folder TEXT, date TEXT, decision TEXT, confidence REAL,
         imap_uid TEXT, last_seen_at TEXT, auto_moved INTEGER DEFAULT 0,
         auto_moved_at TEXT,
         UNIQUE(account,msgid)
-    )""")
-    # legacy database migrations
+    )"""
+    )
+
+    # --- migrations légères ---
+    # On inspecte la structure courante puis on ajoute les colonnes manquantes.
     c.execute("PRAGMA table_info(mails)")
     cols = {row[1] for row in c.fetchall()}
     if "imap_uid" not in cols:
@@ -49,22 +96,36 @@ def db_init():
         c.execute("ALTER TABLE mails ADD COLUMN auto_moved INTEGER DEFAULT 0")
     if "auto_moved_at" not in cols:
         c.execute("ALTER TABLE mails ADD COLUMN auto_moved_at TEXT")
-    c.execute("""CREATE TABLE IF NOT EXISTS models (
+
+    # Table pour suivre l'historique des entraînements réalisés.
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS models (
         id INTEGER PRIMARY KEY, version TEXT, trained_at TEXT
-    )""")
+    )"""
+    )
+
     conn.commit()
     return conn
 
 def clean_text(s):
-    if not s: return ""
-    return re.sub(r"\s+"," ", s).strip()
+    """Nettoie rapidement un texte pour l'encoder plus facilement."""
+
+    if not s:
+        return ""
+
+    # Suppression des espaces multiples et normalisation des sauts de ligne.
+    return re.sub(r"\s+", " ", s).strip()
 
 def vectorize(texts, encoder):
+    """Applique l'encodeur SentenceTransformer et renvoie une matrice numpy."""
+
     emb = encoder.encode(texts, show_progress_bar=False)
     return np.array(emb)
 
 
 def canonical_folder_name(name: str) -> str:
+    """Normalise le nom d'un dossier IMAP (majuscules, séparateur /)."""
+
     if not name:
         return ""
     if isinstance(name, bytes):
@@ -76,14 +137,22 @@ def canonical_folder_name(name: str) -> str:
 
 
 def load_account_mail_types(acc):
+    """Charge les règles de typage personnalisées associées à un compte."""
+
     if not acc:
         return {}
+
+    # On recherche d'abord un chemin défini explicitement dans la config du
+    # compte, sinon on tente un fallback basé sur le nom du compte.
     cfg_path = acc.get("mail_types_config")
     if not cfg_path:
         default_path = MAIL_TYPES_DIR / f"{acc['name']}.json"
         cfg_path = default_path if default_path.exists() else None
     if not cfg_path:
         return {}
+
+    # Lecture du fichier JSON qui décrit les règles. La robustesse est de mise
+    # car un fichier manquant ou mal formé ne doit pas faire planter la synchro.
     try:
         with open(cfg_path, "r", encoding="utf-8") as fh:
             payload = json.load(fh)
@@ -92,6 +161,8 @@ def load_account_mail_types(acc):
     except json.JSONDecodeError as exc:
         print(f"[WARN] invalid mail types JSON for {acc['name']}: {exc}")
         return {}
+
+    # Indexation rapide par clé pour simplifier les lookups plus tard.
     entries = payload.get("types", [])
     index = {e.get("key"): e for e in entries if e.get("key")}
     enabled = {k for k, v in index.items() if v.get("enabled", True)}
@@ -99,15 +170,21 @@ def load_account_mail_types(acc):
 
 
 def _resolve_entry_folders(account_cfg, entry):
+    """Détermine les dossiers IMAP liés à une règle de typage donnée."""
+
     folders = set()
     if not entry:
         return folders
+
     raw = entry.get("source_folders") or []
     if isinstance(raw, str):
         raw = [raw]
     for item in raw:
         if item:
             folders.add(item)
+
+    # Si la règle définit un dossier cible, on l'ajoute aussi pour surveiller
+    # les mouvements et détecter les classifications existantes.
     target = entry.get("target_folder")
     if not target:
         target = account_cfg.get("folders", {}).get("targets", {}).get(entry.get("key"))
@@ -117,6 +194,8 @@ def _resolve_entry_folders(account_cfg, entry):
 
 
 def _collect_archive_roots(account_cfg):
+    """Construit la liste des dossiers considérés comme archives."""
+
     roots = set()
     folders_cfg = account_cfg.get("folders", {}) if account_cfg else {}
     archive_values = []
@@ -133,6 +212,8 @@ def _collect_archive_roots(account_cfg):
 
 
 def _is_archive_folder(folder, archive_roots):
+    """Détermine si un dossier correspond à l'archive (d'où exclusion auto)."""
+
     canon = canonical_folder_name(folder)
     if not canon:
         return False
@@ -148,21 +229,39 @@ def _is_archive_folder(folder, archive_roots):
 
 # === PIPELINE STEPS ===
 def snapshot(cfg):
+    """Réalise une synchronisation IMAP et met à jour la base locale.
+
+    Cette étape collecte les emails des dossiers surveillés, met à jour les
+    métadonnées (sujet, corps, dernier dossier vu) et tient à jour les
+    décisions prises manuellement par l'utilisateur afin d'alimenter l'apprentissage.
+    """
+
     conn = db_init()
     cur = conn.cursor()
+
+    # Ces valeurs servent de fallback si un message disparaît d'INBOX : on les
+    # utilise pour marquer les mails comme supprimés / spam automatiquement.
     delete_pref_keys = {"SPAM", "INDESIRABLE", "JUNK", "PROMOTION", "PROMOTIONS", "NEWSLETTER"}
+
     for acc in cfg.get("accounts", []):
         account_name = acc.get("name")
         if not account_name:
             continue
+
         now_iso = datetime.utcnow().isoformat()
         print(f"{datetime.now()} [{account_name}] snapshot...")
+
+        # On récupère les règles de typage et on prépare des structures pour
+        # suivre la correspondance dossier -> décision.
         mail_types = load_account_mail_types(acc)
         entries = mail_types.get("entries", {})
         enabled_keys = {k for k in mail_types.get("enabled", set()) if entries.get(k)}
         folder_sources = defaultdict(set)
         folder_decisions = {}
         delete_fallback = None
+
+        # On parcourt les règles actives pour déterminer les dossiers sources à
+        # surveiller ainsi que le fallback suppression (spam, promotions...).
         for key in enabled_keys:
             entry = entries.get(key) or {}
             sources = _resolve_entry_folders(acc, entry)
@@ -175,22 +274,32 @@ def snapshot(cfg):
                     folder_decisions[canon] = key
             if not delete_fallback and key and key.upper() in delete_pref_keys:
                 delete_fallback = key
+
         archive_roots = _collect_archive_roots(acc)
         imap = acc["imap"]
         pwd = Path(imap["password_file"]).read_text().strip()
+
+        # On surveille systématiquement l'INBOX et, pour chaque règle, les
+        # dossiers associés (sources + cibles pour détecter les classifications).
         watch_folders = {"INBOX"}
         for folder in folder_sources:
             watch_folders.add(folder)
+
         seen = set()
+
+        # Connexion IMAP : le contexte assure la déconnexion propre.
         with IMAPClient(imap["host"], port=imap["port"], ssl=imap["ssl"]) as srv:
             srv.login(imap["user"], pwd)
             for folder in sorted(watch_folders):
                 try:
+                    # On se met en lecture seule pour éviter de modifier les flags côté serveur.
                     srv.select_folder(folder, readonly=True)
                 except Exception as exc:
                     print(f"[WARN] {account_name} select {folder}: {exc}")
                     continue
                 try:
+                    # Récupération de tous les UID : on ne filtre pas pour ne
+                    # manquer aucun message récent.
                     uids = srv.search()
                 except Exception as exc:
                     print(f"[WARN] {account_name} search {folder}: {exc}")
@@ -202,6 +311,7 @@ def snapshot(cfg):
                 except Exception as exc:
                     print(f"[WARN] {account_name} fetch {folder}: {exc}")
                     continue
+
                 for uid, data in fetched.items():
                     env = data.get(b"ENVELOPE")
                     msgid = None
@@ -218,7 +328,10 @@ def snapshot(cfg):
                             except Exception:
                                 subject = str(env.subject)
                     if not msgid:
+                        # Fallback: on compose un identifiant stable basé sur
+                        # le dossier et l'UID IMAP.
                         msgid = f"{folder}:{uid}"
+
                     body = ""
                     raw_body = data.get(b"BODY[]") or data.get(b"BODY.PEEK[]")
                     try:
@@ -226,13 +339,21 @@ def snapshot(cfg):
                             mp = parse_from_bytes(raw_body)
                             body = mp.text_plain[0] if mp.text_plain else (mp.body or "")
                     except Exception:
+                        # Parsing parfois fragile (emails mal formés) : on ignore l'erreur.
                         pass
+
+                    # Le nettoyage permet d'éviter d'insérer des chaînes
+                    # énormes et mal normalisées dans la base.
                     body = clean_text(body)
                     subject = clean_text(subject)
+
                     canon_folder = canonical_folder_name(folder)
                     decision_for_folder = folder_decisions.get(canon_folder)
                     archive_hit = _is_archive_folder(folder, archive_roots)
+
+                    # Trace que le message a été vu durant ce snapshot.
                     seen.add((account_name, msgid))
+
                     cur.execute(
                         "SELECT id, folder, decision, auto_moved FROM mails WHERE account=? AND msgid=?",
                         (account_name, msgid),
@@ -243,6 +364,7 @@ def snapshot(cfg):
                     if row:
                         row_id, prev_folder, prev_decision, prev_auto = row
                         if prev_folder != folder:
+                            # Déplacement détecté -> on met à jour dossier, UID et timestamps.
                             updates.append("folder=?")
                             params.append(folder)
                             updates.append("imap_uid=?")
@@ -250,9 +372,12 @@ def snapshot(cfg):
                             updates.append("last_seen_at=?")
                             params.append(now_iso)
                             if prev_auto:
+                                # Si le message avait été auto-déplacé on reset
+                                # le flag pour refléter l'action manuelle.
                                 updates.append("auto_moved=0")
                                 updates.append("auto_moved_at=NULL")
                         else:
+                            # Pas de déplacement : on rafraîchit simplement l'horodatage et l'UID.
                             updates.append("last_seen_at=?")
                             params.append(now_iso)
                             updates.append("imap_uid=?")
@@ -266,6 +391,7 @@ def snapshot(cfg):
                         if not archive_hit:
                             if decision_for_folder:
                                 if prev_decision != decision_for_folder:
+                                    # Le dossier surveillé correspond à une règle -> on met à jour la décision.
                                     updates.append("decision=?")
                                     params.append(decision_for_folder)
                                     updates.append("confidence=?")
@@ -274,6 +400,8 @@ def snapshot(cfg):
                                     updates.append("auto_moved_at=?")
                                     params.append(None)
                             elif prev_decision is not None and canon_folder == "INBOX":
+                                # Retour dans l'INBOX : on considère que la
+                                # décision est annulée.
                                 updates.append("decision=NULL")
                                 updates.append("confidence=NULL")
                                 updates.append("auto_moved=0")
@@ -282,6 +410,7 @@ def snapshot(cfg):
                             set_clause = ",".join(updates)
                             cur.execute(f"UPDATE mails SET {set_clause} WHERE id=?", (*params, row_id))
                     else:
+                        # Nouveau message : on insère une ligne complète avec les métadonnées courantes.
                         cur.execute(
                             "INSERT INTO mails (account,msgid,subject,body,folder,date,decision,confidence,imap_uid,last_seen_at,auto_moved) "
                             "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
@@ -299,6 +428,10 @@ def snapshot(cfg):
                                 0,
                             ),
                         )
+
+        # Traitement des messages qui ont disparu de l'INBOX (probablement
+        # supprimés ou classés en spam côté client) : on les marque avec le
+        # fallback défini.
         if delete_fallback and seen:
             cur.execute(
                 "SELECT id, msgid, folder FROM mails WHERE account=? AND folder='INBOX'",
@@ -317,46 +450,72 @@ def snapshot(cfg):
                         row_id,
                     ),
                 )
-    conn.commit(); conn.close()
+
+    conn.commit()
+    conn.close()
 
 def retrain(cfg):
-    conn = db_init(); cur = conn.cursor()
+    """Réentraîne le modèle de classification à partir des données étiquetées."""
+
+    conn = db_init()
+    cur = conn.cursor()
     cur.execute("SELECT subject,body,decision FROM mails WHERE decision IS NOT NULL")
     rows = cur.fetchall()
     if not rows:
-        print("[WARN] no labeled data"); return
+        print("[WARN] no labeled data")
+        return
+
+    # Préparation des features texte (concat sujet + corps) avec nettoyage.
     X = [clean_text(f"{(r[0] or '').strip()} {(r[1] or '').strip()}") for r in rows]
     y = [r[2] for r in rows]
+
     enc_name = cfg["model"]["encoder"]
     print(f"[train] loading encoder {enc_name} ...")
     encoder = SentenceTransformer(enc_name)
+
+    # Passage dans l'encodeur SentenceTransformer pour obtenir des embeddings.
     Xv = vectorize(X, encoder)
     clf = LogisticRegression(max_iter=1000)
-    clf.fit(Xv,y)
-    joblib.dump(clf, MODEL_DIR/"clf.joblib")
-    joblib.dump(encoder, MODEL_DIR/"encoder.joblib")
-    cur.execute("INSERT INTO models(version,trained_at) VALUES (?,?)",
-                (enc_name, datetime.now().isoformat()))
-    conn.commit(); conn.close()
+    clf.fit(Xv, y)
+
+    # Sauvegarde sur disque pour réutilisation future.
+    joblib.dump(clf, MODEL_DIR / "clf.joblib")
+    joblib.dump(encoder, MODEL_DIR / "encoder.joblib")
+
+    cur.execute(
+        "INSERT INTO models(version,trained_at) VALUES (?,?)",
+        (enc_name, datetime.now().isoformat()),
+    )
+    conn.commit()
+    conn.close()
     print("[train] done")
 
 def predict(cfg, auto_move=False):
-    conn = db_init(); cur = conn.cursor()
+    """Effectue des prédictions sur les emails en attente et optionnellement les déplace."""
+
+    conn = db_init()
+    cur = conn.cursor()
     try:
-        clf = joblib.load(MODEL_DIR/"clf.joblib")
-        encoder = joblib.load(MODEL_DIR/"encoder.joblib")
+        clf = joblib.load(MODEL_DIR / "clf.joblib")
+        encoder = joblib.load(MODEL_DIR / "encoder.joblib")
     except Exception:
-        print("[predict] no model, run retrain first"); return
+        print("[predict] no model, run retrain first")
+        return
+
     cur.execute(
         "SELECT id,subject,body,account,imap_uid FROM mails WHERE decision IS NULL AND (folder IS NULL OR UPPER(folder)='INBOX')"
     )
     rows = cur.fetchall()
     if not rows:
-        conn.close(); return
-    X = [clean_text((r[1] or "")+" "+(r[2] or "")) for r in rows]
+        conn.close()
+        return
+
+    # Conversion en embeddings pour le modèle.
+    X = [clean_text((r[1] or "") + " " + (r[2] or "")) for r in rows]
     Xv = vectorize(X, encoder)
     probs = clf.predict_proba(Xv)
     preds = clf.classes_[np.argmax(probs, axis=1)]
+
     accounts_map = {a["name"]: a for a in cfg.get("accounts", []) if a.get("name")}
     mail_types_cache = {}
     min_conf = float(cfg.get("model", {}).get("min_auto_move_confidence", 0.85))
@@ -367,6 +526,8 @@ def predict(cfg, auto_move=False):
         conf = float(np.max(p))
         decision = label
         acc = accounts_map.get(account)
+
+        # Cache des mail types pour éviter de recharger sur disque à chaque message.
         mail_types = mail_types_cache.get(account)
         if mail_types is None:
             mail_types = load_account_mail_types(acc)
@@ -374,11 +535,14 @@ def predict(cfg, auto_move=False):
         entries = mail_types.get("entries", {}) if mail_types else {}
         enabled = mail_types.get("enabled", set()) if mail_types else set()
         entry = entries.get(decision) if entries else None
+
+        # Recherche du dossier cible associé à la décision.
         target = None
         if entry:
             target = entry.get("target_folder") or (acc or {}).get("folders", {}).get("targets", {}).get(decision)
         elif acc:
             target = acc.get("folders", {}).get("targets", {}).get(decision)
+
         log_msg = f"[predict] {account} -> {decision} ({conf:.2f})"
         if not enabled:
             print(log_msg + " [aucune règle active]")
@@ -392,11 +556,14 @@ def predict(cfg, auto_move=False):
         if not target:
             print(log_msg + " [pas de dossier cible]")
             continue
+
         print(log_msg)
         cur.execute(
             "UPDATE mails SET confidence=? WHERE id=?",
             (conf, id_),
         )
+
+        # Optionnellement on déplace le message si le mode auto_move est actif.
         if not (auto_move and acc and acc.get("mode", {}).get("auto_move", False) and conf > min_conf):
             continue
         if imap_uid is None:
@@ -409,6 +576,7 @@ def predict(cfg, auto_move=False):
             continue
         moves_by_account[account].append((id_, uid_int, decision, target, conf))
 
+    # Application des déplacements IMAP regroupés par compte pour limiter les connexions.
     for account, items in moves_by_account.items():
         acc = accounts_map.get(account)
         if not acc:
@@ -431,10 +599,14 @@ def predict(cfg, auto_move=False):
                     "UPDATE mails SET folder=?, decision=?, auto_moved=1, auto_moved_at=?, imap_uid=NULL, confidence=? WHERE id=?",
                     (target, decision, now_iso, conf, row_id),
                 )
-    conn.commit(); conn.close()
+    conn.commit()
+    conn.close()
 
 def stats(cfg):
-    conn = db_init(); cur = conn.cursor()
+    """Affiche des statistiques de labeling par compte et par mode auto-move."""
+
+    conn = db_init()
+    cur = conn.cursor()
     cur.execute(
         """
         SELECT account,
@@ -447,7 +619,7 @@ def stats(cfg):
     )
     rows = cur.fetchall()
     if not rows:
-        print("(no data in mails table)");
+        print("(no data in mails table)")
         return
 
     cur.execute(
@@ -460,6 +632,7 @@ def stats(cfg):
     )
     decision_rows = cur.fetchall()
     conn.close()
+
     decisions_per_account = {}
     for account, decision, count in decision_rows:
         decisions_per_account.setdefault(account, {})[decision] = count
@@ -519,7 +692,9 @@ def stats(cfg):
             print("    · (no labeled decisions)")
 
 def loop(cfg):
-    every = int(cfg["scheduler"].get("poll_every_seconds",600))
+    """Boucle principale : snapshot, prédiction, entraînement périodique."""
+
+    every = int(cfg["scheduler"].get("poll_every_seconds", 600))
     retrain_every = int(cfg["scheduler"].get("retrain_every_seconds", 86400))
     last_retrain = datetime.utcnow() - timedelta(seconds=retrain_every)
     while True:
@@ -531,15 +706,22 @@ def loop(cfg):
         time.sleep(every)
 
 # === CLI ===
-if __name__=="__main__":
-    if len(sys.argv)<2:
-        print("Usage: mailai.py [snapshot|predict|retrain|loop] --config ..."); sys.exit(1)
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: mailai.py [snapshot|predict|retrain|loop] --config ...")
+        sys.exit(1)
     cmd = sys.argv[1]
     cfg = load_cfg()
-    if cmd=="snapshot": snapshot(cfg)
-    elif cmd=="retrain": retrain(cfg)
-    elif cmd=="predict": predict(cfg, auto_move="--auto" in sys.argv)
-    elif cmd=="stats": stats(cfg)
-    elif cmd=="loop": loop(cfg)
+    if cmd == "snapshot":
+        snapshot(cfg)
+    elif cmd == "retrain":
+        retrain(cfg)
+    elif cmd == "predict":
+        predict(cfg, auto_move="--auto" in sys.argv)
+    elif cmd == "stats":
+        stats(cfg)
+    elif cmd == "loop":
+        loop(cfg)
     else:
-        print("Unknown command",cmd); sys.exit(1)
+        print("Unknown command", cmd)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add a module overview and explanatory comments for configuration constants
- document helper functions and CLI subcommands with verbose inline guidance

## Testing
- python - <<'PY'
import py_compile
py_compile.compile('app/bin/accountctl', doraise=True)
print('compiled')
PY

------
https://chatgpt.com/codex/tasks/task_b_68de6eec49ac8331ae7a249a48322bbc