### PR TITLE
feat: anonymize stored mail identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ docker exec -it rpi-mailai python /app/mailai.py --config /config/config.yml pre
 
 The `loop` command now refreshes the snapshot, applies predictions restricted to the INBOX, and triggers a retraining pass at least once every 24 hours to incorporate user corrections (moves, deletions) automatically.
 
+### Configuration note
+
+Ensure `config/config.yml` defines a `hash_salt` entry (any sufficiently random string). The salt is combined with the account name to derive anonymised SHA-256 keys for message tracking, so changing it will alter the identifiers stored in SQLite.
+
 ## Inspect database stats
 
 Aggregate ingestion metrics (total mails, labeled share and decision distribution) per account directly from SQLite:


### PR DESCRIPTION
## Summary
- hash message identifiers with a configurable salt and update the snapshot pipeline to persist anonymised keys
- migrate existing rows during database init while keeping embeddings purge logic and documenting the new config requirement
- refresh documentation to reflect hashed identifiers in the ingestion flow

## Testing
- python -m compileall app/mailai.py

------
https://chatgpt.com/codex/tasks/task_b_68de771b8b388331b4e19b3d7207f1ea