### PR TITLE
Implement IMAP control mailboxes, YAML schema updates, and security hardening

### DIFF
--- a/examples/accounts.yaml
+++ b/examples/accounts.yaml
@@ -1,0 +1,28 @@
+# Example accountctl export with Docker secrets references
+accounts:
+  - name: "personal"
+    imap:
+      host: "imap.example.net"
+      port: 993
+      ssl: true
+      username: "doe@example.net"
+      password_file: "/run/secrets/personal_imap_password"
+      control_namespace: "MailIA"
+      quarantine_subfolder: "Quarantine"
+    secrets:
+      hash_salt: "/run/secrets/global_hash_salt"
+      pepper: "/run/secrets/personal_pepper"
+      sqlcipher_key: "/run/secrets/sqlcipher_key"
+  - name: "work"
+    imap:
+      host: "mail.corp.example"
+      port: 993
+      ssl: true
+      username: "doe@example.com"
+      password_file: "/run/secrets/work_imap_password"
+      control_namespace: "MailIA"
+      quarantine_subfolder: "Quarantine"
+    secrets:
+      hash_salt: "/run/secrets/global_hash_salt"
+      pepper: "/run/secrets/work_pepper"
+      sqlcipher_key: "/run/secrets/sqlcipher_key"

--- a/examples/rules.yaml
+++ b/examples/rules.yaml
@@ -1,31 +1,32 @@
 version: 2
 meta:
-  description: "Default MailAI configuration"
-  owner: "operator@example.com"
-  updated_at: "2025-01-01T00:00:00+00:00"
+  description: "Household triage policy for the Doe family"
+  owner: "doe@example.net"
+  updated_at: "2025-02-12T08:00:00Z"
 schedule:
   learn_cron: "30 2 * * *"
-  inference_interval_s: 60
+  inference_interval_s: 180
 privacy:
   feature_store_path: "/var/lib/mailai/features.db"
   encryption:
     enabled: true
-    key_path: "/etc/mailai/key.bin"
-  hashing_pepper_path: "/etc/mailai/pepper.bin"
-  max_plaintext_window_chars: 0
+    key_path: "/run/secrets/sqlcipher_key"
+  hashing_pepper_path: "/run/secrets/account_pepper"
+  hashing_salt_path: "/run/secrets/global_hash_salt"
+  max_plaintext_window_chars: 1536
 learning:
   enabled: true
-  window_days: 60
-  min_samples_per_class: 20
+  window_days: 30
+  min_samples_per_class: 10
   llm:
     provider: "llama.cpp"
     model: "qwen2.5-3b-instruct-q4_0.gguf"
-    max_tokens: 128
-    temperature: 0.2
+    max_tokens: 256
+    temperature: 0.0
   embeddings:
-    enabled: true
-    backend: "gguf-emb"
-    dim: 384
+    enabled: false
+    backend: null
+    dim: null
   rule_synthesis:
     enabled: true
     max_rules_per_pass: 3
@@ -33,25 +34,44 @@ learning:
   delete_semantics:
     infer_meaning: true
     signals:
-      - "thread_is_resolved"
-      - "list_unsubscribe_present"
-      - "age_gt_days:14"
+      - "calendar_invite_past"
+      - "conversation_closed"
+      - "spam_score_high"
 defaults:
   case_sensitive: false
   stop_on_first_match: false
-  dry_run: false
+  dry_run: true
 rules:
-  - id: move-newsletters
-    description: "Move newsletters to dedicated folder"
+  - id: newsletters
+    description: "Sweep recurring newsletters into the reading list"
+    why: "Keeps marketing material out of the primary inbox while remaining accessible"
+    source: deterministic
+    enabled: true
     priority: 10
     match:
       any:
         - header:
             name: "List-Id"
-            contains: "."
+            contains: "newsletter"
         - subject:
             contains: "newsletter"
     actions:
-      - add_label: "Newsletters"
-      - move_to: "INBOX/Newsletters"
-      - mark_read: true
+      - add_label: "Reading/Newsletters"
+      - move_to: "Reading/Newsletters"
+  - id: family-updates
+    description: "Highlight direct family messages"
+    why: "Ensures important family discussions stay visible"
+    source: deterministic
+    enabled: true
+    priority: 5
+    match:
+      all:
+        - from:
+            contains: "@family.example.net"
+      none:
+        - mailbox:
+            equals: "Reading/Newsletters"
+    actions:
+      - add_label: "Priority/Family"
+      - mark_read: false
+      - stop_processing: true

--- a/examples/status.yaml
+++ b/examples/status.yaml
@@ -1,0 +1,60 @@
+run_id: "2025-02-12T08:15:00Z"
+config_checksum: "sha256:example"
+mailbox: "MailIA"
+last_run_started_at: "2025-02-12T08:15:00Z"
+last_run_finished_at: "2025-02-12T08:15:05Z"
+mode:
+  dry_run: true
+  learner: true
+summary:
+  scanned_messages: 128
+  matched_messages: 46
+  actions_applied: 42
+  errors: 1
+  warnings: 2
+by_rule:
+  newsletters:
+    matches: 30
+    actions: 30
+    errors: 0
+  family-updates:
+    matches: 6
+    actions: 12
+    errors: 0
+learning:
+  last_train_started_at: "2025-02-11T22:00:00Z"
+  last_train_finished_at: "2025-02-11T22:04:30Z"
+  samples_used: 512
+  classes:
+    - "Reading/Newsletters"
+    - "Priority/Family"
+    - "Archive"
+  macro_f1: 0.87
+  proposed_rules: 1
+  delete_semantics:
+    spam_score_high: 12
+    conversation_closed: 4
+privacy:
+  feature_store_encrypted: true
+  plaintext_leaks_detected: 0
+  pepper_rotation_due: false
+notes:
+  - "Observed 2 messages exceeding max size window; they were redacted."
+  - "One IMAP move retried due to transient network error."
+proposals:
+  - rule_id: "auto-1"
+    diff: |
+      + id: "auto-1"
+      + description: "Model-derived rule for feature doe-family"
+      + why: "Automated learner suggested this rule based on consistent gestures"
+      + source: learner
+      + enabled: false
+      + priority: 40
+      + match:
+      +   any:
+      +     - category_pred:
+      +         equals: "Priority/Family"
+      +         prob_gte: 0.85
+      + actions:
+      +   - add_label: "Priority/Family"
+    why: "Repeated manual moves of family threads suggest automating the workflow"

--- a/mailai/README.md
+++ b/mailai/README.md
@@ -42,6 +42,31 @@ and never persists cleartext email data.
 - `mailai learn-now`: trigger the learning pipeline immediately.
 - `mailai diag --redact`: emit a redacted diagnostics report.
 
+## IMAP YAML Configuration
+
+MailAI stores its configuration and diagnostics inside the IMAP account under a
+dedicated control namespace. By default the agent creates a `MailIA/`
+mailbox that contains two human-readable messages:
+
+- **`MailAI: rules.yaml`** – the authoritative configuration described by the
+  [`RulesV2`](mailai/src/mailai/config/schema.py) schema. Every rule must include
+  a human-facing `description`, a justification in `why`, and a `source`
+  indicating whether the rule was `deterministic` or emitted by the
+  `learner`. The agent automatically restores a minimal rule-set if the file is
+  missing or becomes corrupted and keeps a mirror copy as
+  `MailAI: rules.bak.yaml`.
+- **`MailAI: status.yaml`** – the latest diagnostic snapshot following the
+  [`StatusV2`](mailai/src/mailai/config/schema.py) schema. It records aggregate
+  metrics, privacy checks, and a `proposals` section where learner-generated
+  rules are rendered as YAML diffs with an explanation.
+
+Both messages are limited to 128 KB. MailAI attempts to keep the payload below
+64 KB by truncating verbose sections such as `notes` and `proposals` while
+preserving the most relevant entries. Example documents are provided under
+[`examples/rules.yaml`](../examples/rules.yaml) and
+[`examples/status.yaml`](../examples/status.yaml). Account bootstrap data for
+`accountctl` is illustrated in [`examples/accounts.yaml`](../examples/accounts.yaml).
+
 ## Testing
 
 ```bash

--- a/mailai/src/mailai/core/delete_semantics.py
+++ b/mailai/src/mailai/core/delete_semantics.py
@@ -22,6 +22,14 @@ def infer(signals: Iterable[str]) -> Dict[str, DeleteSignal]:
             result[signal] = DeleteSignal(reason="Resolved thread", score=0.6)
         elif signal == "calendar_invite_past":
             result[signal] = DeleteSignal(reason="Past event", score=0.8)
+        elif signal == "spam_score_high":
+            result[signal] = DeleteSignal(reason="Spam classifier confidence high", score=0.95)
+        elif signal == "promotion_sender":
+            result[signal] = DeleteSignal(reason="Promotional blast detected", score=0.75)
+        elif signal == "conversation_closed":
+            result[signal] = DeleteSignal(reason="Conversation archived by user", score=0.65)
+        elif signal == "invite_expired":
+            result[signal] = DeleteSignal(reason="Calendar invite no longer valid", score=0.85)
         elif signal == "list_unsubscribe_present":
             result[signal] = DeleteSignal(reason="Unsubscribe available", score=0.5)
         elif signal.startswith("age_gt_days"):

--- a/mailai/src/mailai/core/features.py
+++ b/mailai/src/mailai/core/features.py
@@ -18,12 +18,12 @@ class FeatureSketch:
     simhash: int
 
 
-def extract_features(raw_message: bytes, *, pepper: bytes) -> Dict[str, object]:
+def extract_features(raw_message: bytes, *, pepper: bytes, salt: bytes) -> Dict[str, object]:
     """Extract hashed features from a raw email message."""
 
     _, headers, body = parse_message(raw_message)
     domains = _extract_domains(headers)
-    hasher = PepperHasher(pepper)
+    hasher = PepperHasher(pepper=pepper, salt=salt)
     tokens = _tokenise(body)
     hashed = hasher.hash_tokens(tokens)
     sketch = FeatureSketch(tokens=hashed[:128], simhash=hasher.simhash(tokens))
@@ -37,10 +37,10 @@ def extract_features(raw_message: bytes, *, pepper: bytes) -> Dict[str, object]:
     }
 
 
-def hash_text_window(text: str, pepper: bytes) -> FeatureSketch:
+def hash_text_window(text: str, *, pepper: bytes, salt: bytes) -> FeatureSketch:
     """Produce a hashed sketch from a text snippet."""
 
-    hasher = PepperHasher(pepper)
+    hasher = PepperHasher(pepper=pepper, salt=salt)
     tokens = _tokenise(text)
     hashed = hasher.hash_tokens(tokens)
     return FeatureSketch(tokens=hashed[:128], simhash=hasher.simhash(tokens))

--- a/mailai/src/mailai/core/privacy.py
+++ b/mailai/src/mailai/core/privacy.py
@@ -92,13 +92,14 @@ class PepperHasher:
     """Peppered hashing of message features for privacy."""
 
     pepper: bytes
+    salt: bytes
 
     def hash_tokens(self, tokens: Iterable[str]) -> List[str]:
         """Hash tokens using SHA-256 and the configured pepper."""
 
         result: List[str] = []
         for token in tokens:
-            digest = hashlib.sha256(self.pepper + token.encode("utf-8")).hexdigest()
+            digest = hashlib.sha256(self.salt + self.pepper + token.encode("utf-8")).hexdigest()
             result.append(digest)
         return result
 
@@ -107,7 +108,7 @@ class PepperHasher:
 
         accum = [0] * 64
         for token in tokens:
-            digest = hashlib.sha256(self.pepper + token.encode("utf-8")).digest()
+            digest = hashlib.sha256(self.salt + self.pepper + token.encode("utf-8")).digest()
             bits = int.from_bytes(digest[:8], "big")
             for idx in range(64):
                 if bits & (1 << idx):

--- a/mailai/src/mailai/core/rule_synthesis.py
+++ b/mailai/src/mailai/core/rule_synthesis.py
@@ -11,6 +11,7 @@ class RuleCandidate:
 
     id: str
     description: str
+    why: str
     match: Dict[str, object]
     actions: List[Dict[str, object]]
     source: str = "learner"
@@ -25,10 +26,12 @@ def synthesise_rules(weights: Dict[str, float], glossary: Dict[str, str], k_max:
     candidates: List[RuleCandidate] = []
     for idx, (feature, weight) in enumerate(top_items, start=1):
         description = f"Model-derived rule for feature {feature}"
+        why = "Automated learner suggested this rule based on consistent gestures"
         mailbox = glossary.get(feature, "INBOX")
         candidate = RuleCandidate(
             id=f"auto-{idx}",
             description=description,
+            why=why,
             match={
                 "any": [
                     {"category_pred": {"equals": mailbox, "prob_gte": 0.85}},

--- a/mailai/src/mailai/imap/client.py
+++ b/mailai/src/mailai/imap/client.py
@@ -1,8 +1,11 @@
 """Wrapper around `imapclient` providing guardrails for MailAI."""
 from __future__ import annotations
 
+import contextlib
+import time
+from collections import deque
 from dataclasses import dataclass
-from typing import Iterable, List, Optional
+from typing import Deque, Iterable, Iterator, List, Optional, Set
 
 try:  # pragma: no cover - optional dependency
     from imapclient import IMAPClient
@@ -20,6 +23,8 @@ class ImapConfig:
     port: int = 993
     ssl: bool = True
     folder: str = "INBOX"
+    control_namespace: str = "MailIA"
+    quarantine_subfolder: str = "Quarantine"
 
 
 class MailAIImapClient:
@@ -28,13 +33,21 @@ class MailAIImapClient:
     def __init__(self, config: ImapConfig):
         self._config = config
         self._client: Optional[IMAPClient] = None
+        self._delimiter: str = "/"
+        self._mailboxes: Set[str] = set()
+        self._selected: Optional[str] = None
+        self._control_mailbox: Optional[str] = None
+        self._quarantine_mailbox: Optional[str] = None
+        self._actions: Deque[float] = deque()
 
     def __enter__(self) -> "MailAIImapClient":
         if IMAPClient is None:
             raise RuntimeError("imapclient dependency is not available")
         self._client = IMAPClient(self._config.host, port=self._config.port, ssl=self._config.ssl)
         self._client.login(self._config.username, self._config.password)
-        self._client.select_folder(self._config.folder, readonly=False)
+        self._refresh_mailboxes()
+        self._bootstrap_control_mailboxes()
+        self._select(self._config.folder)
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:
@@ -55,34 +68,117 @@ class MailAIImapClient:
     def config(self) -> ImapConfig:
         return self._config
 
+    @property
+    def control_mailbox(self) -> str:
+        if self._control_mailbox is None:
+            raise RuntimeError("Control mailbox not initialised")
+        return self._control_mailbox
+
+    @property
+    def quarantine_mailbox(self) -> str:
+        if self._quarantine_mailbox is None:
+            raise RuntimeError("Quarantine mailbox not initialised")
+        return self._quarantine_mailbox
+
+    def _select(self, mailbox: str, *, readonly: bool = False) -> None:
+        mailbox_name = self._ensure_mailbox(mailbox)
+        self.client.select_folder(mailbox_name, readonly=readonly)
+        self._selected = mailbox_name
+
+    def _refresh_mailboxes(self) -> None:
+        self._mailboxes.clear()
+        for flags, delimiter, name in self.client.list_folders():
+            if delimiter:
+                decoded = delimiter.decode() if isinstance(delimiter, bytes) else str(delimiter)
+                if decoded:
+                    self._delimiter = decoded
+            decoded_name = name.decode() if isinstance(name, bytes) else str(name)
+            self._mailboxes.add(decoded_name)
+
+    def _normalize_path(self, *parts: str) -> str:
+        delimiter = self._delimiter or "/"
+        segments: List[str] = []
+        for part in parts:
+            candidate = part.replace("/", delimiter).replace(".", delimiter)
+            for chunk in candidate.split(delimiter):
+                chunk = chunk.strip()
+                if chunk:
+                    segments.append(chunk)
+        return delimiter.join(segments)
+
+    def _ensure_mailbox(self, mailbox: str) -> str:
+        normalized = self._normalize_path(mailbox)
+        if normalized not in self._mailboxes:
+            try:
+                self.client.create_folder(normalized)
+            except Exception:  # pragma: no cover - depends on server implementation
+                self._refresh_mailboxes()
+            else:
+                self._mailboxes.add(normalized)
+        return normalized
+
+    def _bootstrap_control_mailboxes(self) -> None:
+        control = self._normalize_path(self._config.control_namespace)
+        quarantine = self._normalize_path(self._config.control_namespace, self._config.quarantine_subfolder)
+        self._control_mailbox = self._ensure_mailbox(control)
+        self._quarantine_mailbox = self._ensure_mailbox(quarantine)
+        self._ensure_mailbox(self._config.folder)
+
+    def _throttle(self) -> None:
+        now = time.monotonic()
+        while self._actions and now - self._actions[0] > 60:
+            self._actions.popleft()
+        if len(self._actions) >= 500:
+            raise RuntimeError("IMAP action rate limit exceeded")
+        self._actions.append(now)
+
+    @contextlib.contextmanager
+    def control_session(self, *, readonly: bool = False) -> Iterator[str]:
+        previous = self._selected
+        self._select(self.control_mailbox, readonly=readonly)
+        try:
+            yield self.control_mailbox
+        finally:
+            if previous:
+                self._select(previous, readonly=False)
+
     def fetch_headers(self, uids: Iterable[int], data: str = "BODY.PEEK[HEADER]") -> dict:
         return self.client.fetch(uids, data)
 
     def move(self, uid: int, destination: str) -> None:
-        self.client.move(uid, destination)
+        dest = self._ensure_mailbox(destination)
+        self._throttle()
+        self.client.move(uid, dest)
 
     def copy(self, uid: int, destination: str) -> None:
-        self.client.copy(uid, destination)
+        dest = self._ensure_mailbox(destination)
+        self._throttle()
+        self.client.copy(uid, dest)
 
     def add_label(self, uid: int, label: str) -> None:
+        self._throttle()
         self.client.add_gmail_labels(uid, [label])
 
     def mark_read(self, uid: int, read: bool) -> None:
+        self._throttle()
         if read:
             self.client.add_flags(uid, ["\\Seen"])
         else:
             self.client.remove_flags(uid, ["\\Seen"])
 
     def add_flag(self, uid: int, flag: str) -> None:
+        self._throttle()
         self.client.add_flags(uid, [flag])
 
     def set_header(self, uid: int, name: str, value: str) -> None:
         patch = f"{name}: {value}\r\n"
-        self.client.append(self._config.folder, patch.encode("utf-8"))
+        self._throttle()
+        self.client.append(self._selected or self._config.folder, patch.encode("utf-8"))
 
     def uid_search(self, criteria: List[object]) -> List[int]:
         return list(self.client.search(criteria))
 
     def get_rules_email(self, subject: str) -> Optional[int]:
-        uids = self.client.search(["SUBJECT", subject])
+        with self.control_session(readonly=True):
+            uids = self.client.search(["SUBJECT", subject])
         return max(uids) if uids else None

--- a/mailai/src/mailai/imap/rules_mail.py
+++ b/mailai/src/mailai/imap/rules_mail.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 from email.message import EmailMessage
 from typing import Optional
 
-from ..config.loader import LoadedDocument, dump_rules, load_rules
+from typing import Optional
+
+from ..config.loader import LoadedDocument, dump_rules, load_rules, YamlValidationError
 from ..config.schema import RulesV2
 from ..utils.ids import checksum
 from .client import MailAIImapClient
 
 RULES_SUBJECT = "MailAI: rules.yaml"
 RULES_BACKUP_SUBJECT = "MailAI: rules.bak.yaml"
-MAX_BYTES = 200_000
+HARD_LIMIT = 128 * 1024
 
 
 def read_rules(client: MailAIImapClient, *, fallback: Optional[bytes] = None) -> LoadedDocument:
@@ -19,27 +21,30 @@ def read_rules(client: MailAIImapClient, *, fallback: Optional[bytes] = None) ->
 
     uid = client.get_rules_email(RULES_SUBJECT)
     if uid is None:
-        if fallback is None:
-            raise FileNotFoundError("rules.yaml not found in mailbox")
-        document = load_rules(fallback)
-        upsert_rules(client, document.model)
-        return document
-    data = client.client.fetch([uid], [b"RFC822"])[uid][b"RFC822"]
-    return load_rules(data)
+        return _restore_rules(client, fallback)
+    with client.control_session(readonly=True):
+        payload = client.client.fetch([uid], [b"RFC822"])[uid][b"RFC822"]
+    try:
+        document = load_rules(payload)
+    except YamlValidationError:
+        return _repair_rules(client, fallback)
+    _ensure_backup(client, payload)
+    return document
 
 
 def upsert_rules(client: MailAIImapClient, model: RulesV2) -> str:
     """Upload a rules document, replacing previous copies."""
 
     payload = dump_rules(model)
-    if len(payload) > MAX_BYTES:
-        raise ValueError("rules.yaml exceeds 200KB limit")
-    _delete_existing(client, RULES_SUBJECT)
-    message = _build_message(RULES_SUBJECT, payload)
-    client.client.append(client.config.folder, message.as_bytes())
-    _delete_existing(client, RULES_BACKUP_SUBJECT)
-    backup = _build_message(RULES_BACKUP_SUBJECT, payload)
-    client.client.append(client.config.folder, backup.as_bytes())
+    if len(payload) > HARD_LIMIT:
+        raise ValueError("rules.yaml exceeds 128KB hard limit")
+    with client.control_session():
+        _delete_existing(client, RULES_SUBJECT)
+        message = _build_message(RULES_SUBJECT, payload)
+        client.client.append(client.control_mailbox, message.as_bytes())
+        _delete_existing(client, RULES_BACKUP_SUBJECT)
+        backup = _build_message(RULES_BACKUP_SUBJECT, payload)
+        client.client.append(client.control_mailbox, backup.as_bytes())
     return checksum(payload)
 
 
@@ -58,3 +63,44 @@ def _build_message(subject: str, payload: bytes) -> EmailMessage:
     message["To"] = "mailai@local"
     message.set_content(payload.decode("utf-8"))
     return message
+
+
+def _restore_rules(client: MailAIImapClient, fallback: Optional[bytes]) -> LoadedDocument:
+    if fallback is not None:
+        document = load_rules(fallback)
+        upsert_rules(client, document.model)
+        return document
+    minimal = RulesV2.minimal()
+    payload = dump_rules(minimal)
+    upsert_rules(client, minimal)
+    return load_rules(payload)
+
+
+def _repair_rules(client: MailAIImapClient, fallback: Optional[bytes]) -> LoadedDocument:
+    with client.control_session(readonly=True):
+        backup_uid = client.client.search(["SUBJECT", RULES_BACKUP_SUBJECT])
+        if backup_uid:
+            data = client.client.fetch(backup_uid, [b"RFC822"])[backup_uid[-1]][b"RFC822"]
+            try:
+                document = load_rules(data)
+            except YamlValidationError:
+                document = None
+            else:
+                upsert_rules(client, document.model)
+                return document
+    return _restore_rules(client, fallback)
+
+
+def _ensure_backup(client: MailAIImapClient, payload: bytes) -> None:
+    digest = checksum(payload)
+    backup_uid = client.get_rules_email(RULES_BACKUP_SUBJECT)
+    if backup_uid is not None:
+        with client.control_session(readonly=True):
+            stored = client.client.fetch([backup_uid], [b"RFC822"])[backup_uid][b"RFC822"]
+        if checksum(stored) == digest:
+            return
+    with client.control_session():
+        _delete_existing(client, RULES_BACKUP_SUBJECT)
+        message = _build_message(RULES_BACKUP_SUBJECT, payload)
+        client.client.append(client.control_mailbox, message.as_bytes())
+

--- a/mailai/src/mailai/imap/status_mail.py
+++ b/mailai/src/mailai/imap/status_mail.py
@@ -8,22 +8,27 @@ from ..config.schema import StatusV2
 from .client import MailAIImapClient
 
 STATUS_SUBJECT = "MailAI: status.yaml"
-MAX_BYTES = 200_000
+SOFT_LIMIT = 64 * 1024
+HARD_LIMIT = 128 * 1024
 
 
 def upsert_status(client: MailAIImapClient, status: StatusV2) -> None:
     """Upload the latest status YAML, truncating notes when necessary."""
 
     payload = dump_status(status)
-    if len(payload) > MAX_BYTES:
-        raise ValueError("status.yaml exceeds 200KB limit")
-    _delete_existing(client)
-    message = EmailMessage()
-    message["Subject"] = STATUS_SUBJECT
-    message["From"] = "mailai@local"
-    message["To"] = "mailai@local"
-    message.set_content(payload.decode("utf-8"))
-    client.client.append(client.config.folder, message.as_bytes())
+    if len(payload) > SOFT_LIMIT:
+        status = _truncate_status(status)
+        payload = dump_status(status)
+    if len(payload) > HARD_LIMIT:
+        raise ValueError("status.yaml exceeds 128KB limit")
+    with client.control_session():
+        _delete_existing(client)
+        message = EmailMessage()
+        message["Subject"] = STATUS_SUBJECT
+        message["From"] = "mailai@local"
+        message["To"] = "mailai@local"
+        message.set_content(payload.decode("utf-8"))
+        client.client.append(client.control_mailbox, message.as_bytes())
 
 
 def _delete_existing(client: MailAIImapClient) -> None:
@@ -32,3 +37,16 @@ def _delete_existing(client: MailAIImapClient) -> None:
         return
     client.client.delete_messages(uids)
     client.client.expunge()
+
+
+def _truncate_status(status: StatusV2) -> StatusV2:
+    document = status.model_dump()
+    notes = document.get("notes", [])
+    proposals = document.get("proposals", [])
+    truncated_notes = list(notes[:20])
+    if len(notes) > 20:
+        truncated_notes.append("… additional notes truncated …")
+    truncated_proposals = list(proposals[:8])
+    document["notes"] = truncated_notes
+    document["proposals"] = truncated_proposals
+    return StatusV2.model_validate(document)

--- a/mailai/src/mailai/utils/__init__.py
+++ b/mailai/src/mailai/utils/__init__.py
@@ -2,5 +2,12 @@
 
 from .logging import get_logger
 from .ids import new_run_id, checksum
+from .sqlcipher import SqlCipherUnavailable, open_encrypted_database
 
-__all__ = ["get_logger", "new_run_id", "checksum"]
+__all__ = [
+    "get_logger",
+    "new_run_id",
+    "checksum",
+    "SqlCipherUnavailable",
+    "open_encrypted_database",
+]

--- a/mailai/src/mailai/utils/sqlcipher.py
+++ b/mailai/src/mailai/utils/sqlcipher.py
@@ -1,0 +1,46 @@
+"""Helpers for working with SQLCipher encrypted SQLite databases."""
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+try:  # pragma: no cover - optional dependency
+    from pysqlcipher3 import dbapi2 as sqlcipher
+except ImportError:  # pragma: no cover
+    sqlcipher = None  # type: ignore[assignment]
+
+
+class SqlCipherUnavailable(RuntimeError):
+    """Raised when SQLCipher support is not available on the host."""
+
+
+def open_encrypted_database(
+    path: str,
+    *,
+    key: str,
+    pragmas: Optional[Dict[str, str]] = None,
+):
+    """Open an encrypted SQLite database using SQLCipher.
+
+    Parameters
+    ----------
+    path:
+        Filesystem path to the database.
+    key:
+        Secret used to derive the encryption key. The caller is responsible for
+        supplying a suitably random string.
+    pragmas:
+        Additional PRAGMA statements to execute after the database is opened.
+
+    Returns
+    -------
+    Connection
+        A SQLCipher database connection ready for use.
+    """
+
+    if sqlcipher is None:
+        raise SqlCipherUnavailable("SQLCipher driver pysqlcipher3 is required for encrypted stores")
+    connection = sqlcipher.connect(path)
+    connection.execute("PRAGMA key = ?", (key,))
+    for pragma, value in (pragmas or {}).items():
+        connection.execute(f"PRAGMA {pragma} = {value}")
+    return connection

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+from mailai.imap.client import ImapConfig, MailAIImapClient
+
+UNIT_DIR = Path(__file__).resolve().parent
+if str(UNIT_DIR) not in sys.path:
+    sys.path.insert(0, str(UNIT_DIR))
+
+from fakes import FakeImapBackend
+
+
+@pytest.fixture
+def imap_client(monkeypatch):
+    backend = FakeImapBackend()
+    monkeypatch.setattr("mailai.imap.client.IMAPClient", lambda host, port, ssl: backend)
+    config = ImapConfig(host="localhost", username="user", password="pass")
+    with MailAIImapClient(config) as client:
+        yield client, backend

--- a/tests/unit/fakes.py
+++ b/tests/unit/fakes.py
@@ -1,0 +1,85 @@
+"""Test doubles for IMAP interactions."""
+from __future__ import annotations
+
+import email
+from typing import Dict
+
+
+class FakeImapBackend:
+    """In-memory IMAP backend implementing a subset of `imapclient.IMAPClient`."""
+
+    def __init__(self) -> None:
+        self.mailboxes: Dict[str, Dict[int, Dict[str, object]]] = {
+            "INBOX": {},
+            "MailIA": {},
+            "MailIA/Quarantine": {},
+        }
+        self.selected = "INBOX"
+        self.uid_counter = 1
+
+    # Session management -------------------------------------------------
+    def login(self, username: str, password: str) -> None:  # pragma: no cover - trivial
+        return None
+
+    def logout(self) -> None:  # pragma: no cover - trivial
+        return None
+
+    # Mailbox helpers ----------------------------------------------------
+    def list_folders(self):
+        return [([], "/", name) for name in sorted(self.mailboxes)]
+
+    def create_folder(self, name: str) -> None:
+        self.mailboxes.setdefault(name, {})
+
+    def select_folder(self, name: str, readonly: bool = False) -> None:
+        self.create_folder(name)
+        self.selected = name
+
+    # Message operations -------------------------------------------------
+    def search(self, criteria):
+        subject = criteria[1]
+        return [uid for uid, msg in self.mailboxes[self.selected].items() if msg["subject"] == subject]
+
+    def fetch(self, uids, parts):
+        data = {}
+        for uid in uids:
+            payload = self.mailboxes[self.selected][uid]["payload"]
+            data[uid] = {b"RFC822": payload}
+        return data
+
+    def append(self, mailbox: str, message_bytes: bytes) -> None:
+        self.create_folder(mailbox)
+        message = email.message_from_bytes(message_bytes)
+        payload = message.get_payload(decode=True)
+        if payload is None:
+            payload = message.get_payload().encode()
+        self.mailboxes[mailbox][self.uid_counter] = {
+            "subject": message["Subject"],
+            "payload": payload,
+        }
+        self.uid_counter += 1
+
+    def delete_messages(self, uids) -> None:
+        for uid in uids:
+            self.mailboxes[self.selected].pop(uid, None)
+
+    def expunge(self) -> None:  # pragma: no cover - trivial
+        return None
+
+    # Action helpers -----------------------------------------------------
+    def move(self, uid: int, destination: str) -> None:
+        self.create_folder(destination)
+        self.mailboxes[destination][uid] = self.mailboxes[self.selected].pop(uid)
+
+    def copy(self, uid: int, destination: str) -> None:
+        self.create_folder(destination)
+        self.mailboxes[destination][uid] = dict(self.mailboxes[self.selected][uid])
+
+    def add_gmail_labels(self, uid, labels) -> None:  # pragma: no cover - unused in tests
+        return None
+
+    def add_flags(self, uid, flags) -> None:  # pragma: no cover - unused in tests
+        return None
+
+    def remove_flags(self, uid, flags) -> None:  # pragma: no cover - unused in tests
+        return None

--- a/tests/unit/test_delete_semantics.py
+++ b/tests/unit/test_delete_semantics.py
@@ -1,0 +1,11 @@
+import pytest
+
+from mailai.core import delete_semantics
+
+
+def test_delete_semantics_interprets_signals():
+    signals = ["spam_score_high", "invite_expired", "thread_is_resolved"]
+    result = delete_semantics.infer(signals)
+    assert result["spam_score_high"].reason == "Spam classifier confidence high"
+    assert result["invite_expired"].score == pytest.approx(0.85, rel=1e-3)
+    assert "Resolved thread" in result["thread_is_resolved"].reason

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -41,6 +41,7 @@ def _build_rules(stop_on_first: bool = False):
             "feature_store_path": "/tmp/features.db",
             "encryption": {"enabled": True, "key_path": "/tmp/key.bin"},
             "hashing_pepper_path": "/tmp/pepper.bin",
+            "hashing_salt_path": "/tmp/salt.bin",
             "max_plaintext_window_chars": 0,
         },
         "learning": {
@@ -70,6 +71,8 @@ def _build_rules(stop_on_first: bool = False):
             {
                 "id": "rule1",
                 "description": "mark updates",
+                "why": "Ensures weekly update threads are prioritised",
+                "source": "deterministic",
                 "priority": 5,
                 "enabled": True,
                 "match": {
@@ -89,6 +92,8 @@ def _build_rules(stop_on_first: bool = False):
             {
                 "id": "rule2",
                 "description": "fallback",
+                "why": "Catch unmatched updates for auditing",
+                "source": "deterministic",
                 "priority": 10,
                 "enabled": True,
                 "match": {"any": [{"subject": {"contains": "update"}}]},

--- a/tests/unit/test_privacy.py
+++ b/tests/unit/test_privacy.py
@@ -12,7 +12,7 @@ def test_encrypt_roundtrip():
 
 def test_peppered_hashing():
     pepper = b"pepper"
-    hasher = privacy.PepperHasher(pepper)
+    hasher = privacy.PepperHasher(pepper=pepper, salt=b"salt")
     tokens = ["hello", "world"]
     hashed = hasher.hash_tokens(tokens)
     assert len(hashed) == 2

--- a/tests/unit/test_rules_mail.py
+++ b/tests/unit/test_rules_mail.py
@@ -1,0 +1,38 @@
+import pytest
+
+from mailai.config.loader import load_rules
+from mailai.config.schema import RulesV2
+from mailai.imap.rules_mail import RULES_SUBJECT, read_rules, upsert_rules
+
+
+def test_read_rules_bootstraps_minimal(imap_client):
+    client, backend = imap_client
+    document = read_rules(client)
+    assert isinstance(document.model, RulesV2)
+    assert document.model.meta.description == "Default MailAI policy"
+    assert RULES_SUBJECT in [msg["subject"] for msg in backend.mailboxes[client.control_mailbox].values()]
+
+
+def test_read_rules_repairs_corruption(imap_client):
+    client, backend = imap_client
+    document = read_rules(client)
+    assert document.model.version == 2
+    # Corrupt the primary rules message while keeping the backup intact.
+    mailbox = backend.mailboxes[client.control_mailbox]
+    for uid, entry in mailbox.items():
+        if entry["subject"] == RULES_SUBJECT:
+            entry["payload"] = b"not: yaml"
+            break
+    restored = read_rules(client)
+    assert restored.model.version == 2
+    payloads = [entry["payload"] for entry in backend.mailboxes[client.control_mailbox].values()]
+    assert all(payload != b"not: yaml" for payload in payloads)
+
+
+def test_upsert_rules_enforces_limits(imap_client):
+    client, backend = imap_client
+    model = RulesV2.minimal()
+    upsert_rules(client, model)
+    stored = next(entry["payload"] for entry in backend.mailboxes[client.control_mailbox].values() if entry["subject"] == RULES_SUBJECT)
+    reloaded = load_rules(stored)
+    assert reloaded.model.meta.description == "Default MailAI policy"

--- a/tests/unit/test_sqlcipher.py
+++ b/tests/unit/test_sqlcipher.py
@@ -1,0 +1,34 @@
+import pytest
+
+from mailai.utils.sqlcipher import SqlCipherUnavailable, open_encrypted_database
+
+
+def test_open_encrypted_database_executes_pragmas(monkeypatch):
+    executed = []
+
+    class FakeConnection:
+        def execute(self, sql, params=None):
+            executed.append((sql, params))
+            return None
+
+    class FakeDriver:
+        def connect(self, path):
+            executed.append(("connect", path))
+            return FakeConnection()
+
+    fake_driver = FakeDriver()
+    module = __import__("mailai.utils.sqlcipher", fromlist=["sqlcipher"])
+    monkeypatch.setattr(module, "sqlcipher", fake_driver, raising=False)
+
+    conn = open_encrypted_database("/tmp/test.db", key="secret", pragmas={"cipher_memory_security": "ON"})
+    assert executed[0] == ("connect", "/tmp/test.db")
+    assert ("PRAGMA key = ?", ("secret",)) in executed
+    assert ("PRAGMA cipher_memory_security = ON", None) in executed
+    assert isinstance(conn, FakeConnection)
+
+
+def test_open_encrypted_database_requires_driver(monkeypatch):
+    module = __import__("mailai.utils.sqlcipher", fromlist=["sqlcipher"])
+    monkeypatch.setattr(module, "sqlcipher", None, raising=False)
+    with pytest.raises(SqlCipherUnavailable):
+        open_encrypted_database("/tmp/test.db", key="secret")

--- a/tests/unit/test_status_mail.py
+++ b/tests/unit/test_status_mail.py
@@ -1,0 +1,23 @@
+from mailai.config.loader import load_status
+from mailai.config.schema import Proposal, StatusV2
+from mailai.imap.status_mail import upsert_status
+
+
+def test_upsert_status_truncates_large_payload(imap_client):
+    client, backend = imap_client
+    status = StatusV2.minimal()
+    status.notes = [f"note {idx} " + "x" * 1024 for idx in range(150)]
+    status.proposals = [
+        Proposal(rule_id=f"auto-{idx}", diff="+ sample", why="test proposal")
+        for idx in range(20)
+    ]
+    upsert_status(client, status)
+    stored = next(
+        entry["payload"]
+        for entry in backend.mailboxes[client.control_mailbox].values()
+        if entry["subject"] == "MailAI: status.yaml"
+    )
+    assert len(stored) <= 128 * 1024
+    parsed = load_status(stored)
+    assert len(parsed.model.notes) <= 21  # 20 original + truncation marker
+    assert len(parsed.model.proposals) <= 8


### PR DESCRIPTION
## Summary
- extend the rules and status schemas with required justification metadata, default builders, and stricter validation plus refreshed documentation
- harden YAML parsing/serialisation and IMAP handling by introducing control mailbox bootstrap, rule backup/repair, size-aware status truncation, and SQLCipher helpers
- add privacy, dry-run, and gesture interpretation updates alongside refreshed examples and comprehensive unit coverage for IMAP repairs, truncation, and encryption helpers

## Testing
- python -m compileall mailai/src
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dea1db8ad88331b7c443fcc8bccfa9