### PR TITLE
Centralize runtime configuration via config.cfg

### DIFF
--- a/examples/accounts.yaml
+++ b/examples/accounts.yaml
@@ -7,7 +7,7 @@ accounts:
       ssl: true
       username: "doe@example.net"
       password_file: "/run/secrets/personal_imap_password"
-      control_namespace: "MailIA"
+      control_namespace: "Drafts"
       quarantine_subfolder: "Quarantine"
     secrets:
       hash_salt: "/run/secrets/global_hash_salt"
@@ -20,7 +20,7 @@ accounts:
       ssl: true
       username: "doe@example.com"
       password_file: "/run/secrets/work_imap_password"
-      control_namespace: "MailIA"
+      control_namespace: "Drafts"
       quarantine_subfolder: "Quarantine"
     secrets:
       hash_salt: "/run/secrets/global_hash_salt"

--- a/examples/config.cfg
+++ b/examples/config.cfg
@@ -1,0 +1,32 @@
+version: 1
+paths:
+  state_dir: /var/lib/mailai
+  config_dir: /etc/mailai
+  models_dir: /var/lib/mailai/models
+imap:
+  default_mailbox: INBOX
+  control_namespace: Drafts
+  quarantine_subfolder: Quarantine
+mail:
+  rules:
+    subject: "MailAI: rules.yaml"
+    folder: Drafts
+    limits:
+      soft_limit: 65536
+      hard_limit: 131072
+  status:
+    subject: "MailAI: status.yaml"
+    folder: Drafts
+    limits:
+      soft_limit: 65536
+      hard_limit: 131072
+llm:
+  model_path: /var/lib/mailai/models/qwen2.5-3b-instruct-q4_0.gguf
+  threads: 3
+  ctx_size: 2048
+  sentinel_path: /var/lib/mailai/.cache/llm_ready.json
+  max_age: 86400
+feedback:
+  enabled: false
+  mailbox: Drafts/Feedback
+  subject_prefix: "MailAI Feedback"

--- a/examples/status.yaml
+++ b/examples/status.yaml
@@ -1,6 +1,6 @@
 run_id: "2025-02-12T08:15:00Z"
 config_checksum: "sha256:example"
-mailbox: "MailIA"
+mailbox: "Drafts"
 last_run_started_at: "2025-02-12T08:15:00Z"
 last_run_finished_at: "2025-02-12T08:15:05Z"
 mode:

--- a/mailai/AGENT.md
+++ b/mailai/AGENT.md
@@ -27,7 +27,7 @@ Threat modelling quick-reference:
 ## Operational flows
 
 - `mailai once`: run a single inference pass against the selected account. The
-  agent mounts the `MailIA/` control mailbox, restores missing configuration if
+  agent mounts the `Drafts` control mailbox, restores missing configuration if
   required, and emits a fresh `status.yaml` snapshot in dry-run mode by default.
 - `mailai watch`: identical to `once` but loops according to the configured
   `schedule.inference_interval_s`. Auto-repair logic for `rules.yaml` is invoked

--- a/mailai/README.md
+++ b/mailai/README.md
@@ -42,10 +42,24 @@ and never persists cleartext email data.
 - `mailai learn-now`: trigger the learning pipeline immediately.
 - `mailai diag --redact`: emit a redacted diagnostics report.
 
+## Global runtime configuration
+
+MailAI centralises all runtime tunables inside a single `config.cfg` file. The
+loader accepts either YAML or JSON and validates the payload against the
+[`RuntimeConfig`](mailai/src/mailai/config/schema.py) schema. Typical settings
+include IMAP defaults (control namespace, quarantine folder, configuration
+subjects), size limits for the control mails, filesystem paths for state and
+models, local LLM parameters, and optional feedback mailboxes.
+
+When running inside Docker place `config.cfg` under `/etc/mailai/`. Native
+deployments search the current working directory first and fall back to
+`/etc/mailai/config.cfg` and `/var/lib/mailai/config.cfg`. A reference document
+is available under [`examples/config.cfg`](../examples/config.cfg).
+
 ## IMAP YAML Configuration
 
 MailAI stores its configuration and diagnostics inside the IMAP account under a
-dedicated control namespace. By default the agent creates a `MailIA/`
+dedicated control namespace. By default the agent reuses the standard `Drafts`
 mailbox that contains two human-readable messages:
 
 - **`MailAI: rules.yaml`** – the authoritative configuration described by the
@@ -60,9 +74,10 @@ mailbox that contains two human-readable messages:
   metrics, privacy checks, and a `proposals` section where learner-generated
   rules are rendered as YAML diffs with an explanation.
 
-Both messages are limited to 128 KB. MailAI attempts to keep the payload below
-64 KB by truncating verbose sections such as `notes` and `proposals` while
-preserving the most relevant entries. Example documents are provided under
+Both messages inherit their soft and hard size limits from `config.cfg`. MailAI
+attempts to keep the payload below the soft ceiling by truncating verbose
+sections such as `notes` and `proposals` while preserving the most relevant
+entries. Example documents are provided under
 [`examples/rules.yaml`](../examples/rules.yaml) and
 [`examples/status.yaml`](../examples/status.yaml). Account bootstrap data for
 `accountctl` is illustrated in [`examples/accounts.yaml`](../examples/accounts.yaml).

--- a/mailai/src/mailai/config/__init__.py
+++ b/mailai/src/mailai/config/__init__.py
@@ -1,14 +1,26 @@
 """Configuration schemas and loaders for MailAI."""
 
-from .loader import load_rules, load_status, dump_rules, dump_status
-from .schema import RulesV2, StatusV2, ValidationError
+from .loader import (
+    dump_rules,
+    dump_status,
+    get_runtime_config,
+    load_runtime_config,
+    load_rules,
+    load_status,
+    reset_runtime_config,
+)
+from .schema import RulesV2, RuntimeConfig, StatusV2, ValidationError
 
 __all__ = [
     "load_rules",
     "load_status",
     "dump_rules",
     "dump_status",
+    "get_runtime_config",
+    "load_runtime_config",
+    "reset_runtime_config",
     "RulesV2",
+    "RuntimeConfig",
     "StatusV2",
     "ValidationError",
 ]

--- a/mailai/src/mailai/config/backup.py
+++ b/mailai/src/mailai/config/backup.py
@@ -1,0 +1,64 @@
+"""Encrypted backup store for `rules.yaml`."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..core.privacy import decrypt, encrypt, KEY_SIZE
+from ..config import yamlshim
+from ..config.schema import RulesV2
+
+
+class BackupError(RuntimeError):
+    """Raised when backup encryption or decryption fails."""
+
+
+class EncryptedRulesBackup:
+    """Persist the last known good rules document encrypted at rest."""
+
+    def __init__(self, path: Path, key: bytes):
+        if len(key) != KEY_SIZE:
+            raise ValueError("Backup key must be 32 bytes")
+        self._path = Path(path)
+        self._key = key
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def save(self, yaml_text: str) -> None:
+        """Persist a validated rules document."""
+
+        payload = yaml_text.encode("utf-8")
+        blob = encrypt(payload, self._key)
+        self._path.write_bytes(blob)
+
+    def load_or_minimal(self) -> str:
+        """Return the stored configuration or a minimal template when unavailable."""
+
+        try:
+            blob = self._path.read_bytes()
+        except FileNotFoundError:
+            return _minimal_yaml()
+        try:
+            data = decrypt(blob, self._key)
+        except Exception as exc:
+            raise BackupError("Failed to decrypt rules backup") from exc
+        return data.decode("utf-8")
+
+    def last_known_good(self) -> str:
+        """Return the stored configuration or fall back to the minimal template."""
+
+        try:
+            blob = self._path.read_bytes()
+        except FileNotFoundError:
+            return _minimal_yaml()
+        try:
+            data = decrypt(blob, self._key)
+        except Exception:
+            return _minimal_yaml()
+        return data.decode("utf-8")
+
+    def has_backup(self) -> bool:
+        return self._path.exists()
+
+
+def _minimal_yaml() -> str:
+    minimal = RulesV2.minimal()
+    return yamlshim.dump(minimal.model_dump(mode="json"))

--- a/mailai/src/mailai/config/loader.py
+++ b/mailai/src/mailai/config/loader.py
@@ -1,59 +1,190 @@
-"""Utilities for loading and validating YAML configuration files."""
+"""Utilities for loading MailAI configuration documents."""
+
 from __future__ import annotations
 
 import hashlib
+import json
+import os
 from dataclasses import dataclass
-from typing import Any
+from pathlib import Path
+from typing import Any, Iterable, Optional, Tuple
 
-from .schema import RulesV2, StatusV2, ValidationError
+from pydantic import ValidationError as _PydanticValidationError
+
 from . import yamlshim
+from .schema import (
+    RulesV2,
+    RuntimeConfig,
+    StatusV2,
+    ValidationError,
+)
+
+
+class ConfigLoadError(Exception):
+    """Raised when configuration parsing or validation fails."""
+
+
+class RuntimeConfigError(ConfigLoadError):
+    """Raised when the runtime configuration cannot be loaded."""
+
+
+class YamlValidationError(ConfigLoadError):
+    """Backward compatible alias for :class:`ConfigLoadError`."""
 
 
 @dataclass
 class LoadedDocument:
-    """Wrapper containing both the parsed model and raw YAML bytes."""
+    """Wrapper containing both the parsed model and raw YAML text."""
 
     model: Any
-    raw: bytes
+    raw: str
     checksum: str
 
 
-class YamlValidationError(ValueError):
-    """Raised when YAML fails validation against the Pydantic schema."""
+_CONFIG_ENV = "MAILAI_CONFIG_PATH"
+_DEFAULT_LOCATIONS: Tuple[Path, ...] = (
+    Path("config.cfg"),
+    Path("/etc/mailai/config.cfg"),
+    Path("/var/lib/mailai/config.cfg"),
+)
+_RUNTIME_CACHE: Optional[Tuple[Path, RuntimeConfig]] = None
 
 
-def _load_yaml_document(source: bytes) -> Any:
+def _candidate_paths(path: Optional[Path]) -> Iterable[Path]:
+    seen: set[Path] = set()
+    if path is not None:
+        candidate = path.expanduser()
+        if candidate not in seen:
+            seen.add(candidate)
+            yield candidate
+    env_path = os.environ.get(_CONFIG_ENV)
+    if env_path:
+        candidate = Path(env_path).expanduser()
+        if candidate not in seen:
+            seen.add(candidate)
+            yield candidate
+    for default in _DEFAULT_LOCATIONS:
+        candidate = default.expanduser()
+        if candidate not in seen:
+            seen.add(candidate)
+            yield candidate
+
+
+def _parse_config_payload(text: str, source: Path) -> dict[str, Any]:
+    stripped = text.lstrip()
+    if source.suffix.lower() == ".json" or stripped.startswith("{"):
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise RuntimeConfigError(f"Invalid JSON in {source}: {exc}") from exc
+    else:
+        try:
+            payload = yamlshim.load(text.encode("utf-8")) or {}
+        except Exception as exc:
+            raise RuntimeConfigError(f"Invalid YAML in {source}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeConfigError("config.cfg must contain a mapping at the top-level")
+    return payload
+
+
+def _load_runtime_from_path(path: Path) -> RuntimeConfig:
     try:
-        return yamlshim.load(source) or {}
+        text = path.read_text()
+    except FileNotFoundError as exc:
+        raise RuntimeConfigError(f"Configuration file missing: {path}") from exc
+    except OSError as exc:  # pragma: no cover - filesystem surface
+        raise RuntimeConfigError(f"Unable to read configuration file {path}: {exc}") from exc
+    payload = _parse_config_payload(text, path)
+    try:
+        return RuntimeConfig.model_validate(payload)
+    except _PydanticValidationError as exc:
+        raise RuntimeConfigError(f"Invalid config.cfg: {exc}") from exc
+
+
+def load_runtime_config(
+    path: Optional[Path | str] = None,
+    *,
+    reload: bool = False,
+) -> RuntimeConfig:
+    """Load the runtime configuration from ``config.cfg``."""
+
+    global _RUNTIME_CACHE
+
+    requested_path = Path(path).expanduser() if isinstance(path, (str, Path)) else None
+    if not reload and _RUNTIME_CACHE is not None:
+        cached_path, cached_config = _RUNTIME_CACHE
+        if requested_path is None or cached_path == requested_path:
+            return cached_config
+
+    errors: list[str] = []
+    for candidate in _candidate_paths(requested_path):
+        if not candidate.exists():
+            errors.append(str(candidate))
+            continue
+        config = _load_runtime_from_path(candidate)
+        _RUNTIME_CACHE = (candidate, config)
+        return config
+
+    searched = ", ".join(errors) if errors else "<none>"
+    raise RuntimeConfigError(f"Unable to locate config.cfg (searched: {searched})")
+
+
+def get_runtime_config() -> RuntimeConfig:
+    """Return the cached runtime configuration, loading it if required."""
+
+    return load_runtime_config()
+
+
+def reset_runtime_config() -> None:
+    """Clear the runtime configuration cache (useful in tests)."""
+
+    global _RUNTIME_CACHE
+    _RUNTIME_CACHE = None
+
+
+def parse_and_validate(yaml_text: str) -> RulesV2:
+    """Parse and validate a rules YAML document returning the pydantic model."""
+
+    try:
+        payload = yamlshim.load(yaml_text.encode("utf-8")) or {}
     except Exception as exc:  # pragma: no cover - passthrough for context
-        raise YamlValidationError(f"Invalid YAML: {exc}") from exc
+        raise ConfigLoadError(f"Invalid YAML: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ConfigLoadError("rules.yaml must contain a mapping at the top-level")
+    try:
+        return RulesV2.model_validate(payload)
+    except ValidationError as exc:
+        raise ConfigLoadError(str(exc)) from exc
 
 
-def _checksum(data: bytes) -> str:
-    digest = hashlib.sha256(data).hexdigest()
+def _checksum(text: str) -> str:
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
     return f"sha256:{digest}"
 
 
 def load_rules(source: bytes) -> LoadedDocument:
-    """Load and validate a rules document."""
+    """Load a rules document from bytes and validate it."""
 
-    payload = _load_yaml_document(source)
-    try:
-        model = RulesV2.model_validate(payload)
-    except ValidationError as exc:
-        raise YamlValidationError(str(exc)) from exc
-    return LoadedDocument(model=model, raw=source, checksum=_checksum(source))
+    text = source.decode("utf-8")
+    model = parse_and_validate(text)
+    return LoadedDocument(model=model, raw=text, checksum=_checksum(text))
 
 
 def load_status(source: bytes) -> LoadedDocument:
     """Load and validate a status document."""
 
-    payload = _load_yaml_document(source)
+    try:
+        payload = yamlshim.load(source) or {}
+    except Exception as exc:  # pragma: no cover - passthrough for context
+        raise ConfigLoadError(f"Invalid YAML: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ConfigLoadError("status.yaml must contain a mapping at the top-level")
     try:
         model = StatusV2.model_validate(payload)
     except ValidationError as exc:
-        raise YamlValidationError(str(exc)) from exc
-    return LoadedDocument(model=model, raw=source, checksum=_checksum(source))
+        raise ConfigLoadError(str(exc)) from exc
+    text = yamlshim.dump(model.model_dump(mode="json"))
+    return LoadedDocument(model=model, raw=text, checksum=_checksum(text))
 
 
 def dump_rules(model: RulesV2) -> bytes:

--- a/mailai/src/mailai/config/status_store.py
+++ b/mailai/src/mailai/config/status_store.py
@@ -1,0 +1,70 @@
+"""Persistence helpers for `status.yaml`."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from .loader import dump_status, load_status
+from .schema import ConfigReference, StatusEvent, StatusV2
+from ..imap.rules_mail import RulesMailRef
+
+
+class StatusStore:
+    """Persist and mutate the status snapshot stored on disk."""
+
+    def __init__(self, path: Path):
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        if not self._path.exists():
+            self.save(StatusV2.minimal())
+
+    def load(self) -> StatusV2:
+        try:
+            document = load_status(self._path.read_bytes())
+        except FileNotFoundError:
+            status = StatusV2.minimal()
+            self.save(status)
+            return status
+        return document.model
+
+    def save(self, status: StatusV2) -> None:
+        self._path.write_bytes(dump_status(status))
+
+    def current_config_ref(self) -> Optional[ConfigReference]:
+        return self.load().config_ref
+
+    def update_config_ref(self, ref: RulesMailRef, *, reset_errors: bool = True) -> None:
+        status = self.load()
+        status.config_ref = ConfigReference(
+            uid=ref.uid,
+            message_id=ref.message_id,
+            internaldate=ref.internaldate.isoformat(),
+            checksum=ref.checksum,
+        )
+        status.config_checksum = ref.checksum
+        if reset_errors:
+            status.summary.errors = 0
+        status.restored_rules_from_backup = False
+        self.save(status)
+
+    def mark_restored(self, from_backup: bool) -> None:
+        status = self.load()
+        status.restored_rules_from_backup = from_backup
+        self.save(status)
+
+    def mark_invalid(self) -> None:
+        status = self.load()
+        status.summary.errors = max(status.summary.errors, 1)
+        self.save(status)
+
+    def append_event(self, event_type: str, details: str) -> None:
+        status = self.load()
+        status.events.append(
+            StatusEvent(
+                ts=datetime.now(timezone.utc).isoformat(),
+                type=event_type,  # type: ignore[arg-type]
+                details=details,
+            )
+        )
+        self.save(status)

--- a/mailai/src/mailai/config/watcher.py
+++ b/mailai/src/mailai/config/watcher.py
@@ -1,0 +1,35 @@
+"""Helpers for detecting configuration changes."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .schema import ConfigReference
+from ..imap.rules_mail import RulesMailRef
+
+
+def has_changed(prev: Optional[ConfigReference], new: Optional[RulesMailRef]) -> bool:
+    """Return ``True`` when the configuration reference has changed."""
+
+    if new is None:
+        return prev is not None
+    if prev is None:
+        return True
+    if prev.uid != new.uid:
+        return True
+    return prev.checksum != new.checksum
+
+
+def change_reason(prev: Optional[ConfigReference], new: Optional[RulesMailRef]) -> str:
+    """Return a human readable reason for the change detection."""
+
+    if prev is None and new is None:
+        return "missing"
+    if prev is None:
+        return "bootstrap"
+    if new is None:
+        return "missing"
+    if prev.uid != new.uid:
+        return "uid change"
+    if prev.checksum != new.checksum:
+        return "checksum change"
+    return "unchanged"

--- a/mailai/src/mailai/core/__init__.py
+++ b/mailai/src/mailai/core/__init__.py
@@ -1,9 +1,5 @@
 """Core subsystems for MailAI."""
 
-from .engine import Engine, Message
-from .features import FeatureSketch, extract_features, hash_text_window
-from .learner import Example, LearningCfg, Metrics, ModelBundle, Prediction
-
 __all__ = [
     "Engine",
     "Message",
@@ -16,3 +12,19 @@ __all__ = [
     "ModelBundle",
     "Prediction",
 ]
+
+
+def __getattr__(name: str):
+    if name in {"Engine", "Message"}:
+        from . import engine
+
+        return getattr(engine, name)
+    if name in {"FeatureSketch", "extract_features", "hash_text_window"}:
+        from . import features
+
+        return getattr(features, name)
+    if name in {"Example", "LearningCfg", "Metrics", "ModelBundle", "Prediction"}:
+        from . import learner
+
+        return getattr(learner, name)
+    raise AttributeError(name)

--- a/mailai/src/mailai/imap/status_mail.py
+++ b/mailai/src/mailai/imap/status_mail.py
@@ -3,36 +3,35 @@ from __future__ import annotations
 
 from email.message import EmailMessage
 
-from ..config.loader import dump_status
+from ..config.loader import dump_status, get_runtime_config
 from ..config.schema import StatusV2
 from .client import MailAIImapClient
-
-STATUS_SUBJECT = "MailAI: status.yaml"
-SOFT_LIMIT = 64 * 1024
-HARD_LIMIT = 128 * 1024
-
 
 def upsert_status(client: MailAIImapClient, status: StatusV2) -> None:
     """Upload the latest status YAML, truncating notes when necessary."""
 
+    settings = get_runtime_config()
+    status_cfg = settings.mail.status
+    limits = status_cfg.limits
     payload = dump_status(status)
-    if len(payload) > SOFT_LIMIT:
+    if len(payload) > limits.soft_limit:
         status = _truncate_status(status)
         payload = dump_status(status)
-    if len(payload) > HARD_LIMIT:
-        raise ValueError("status.yaml exceeds 128KB limit")
-    with client.control_session():
-        _delete_existing(client)
+    if len(payload) > limits.hard_limit:
+        raise ValueError("status.yaml exceeds hard size limit")
+    target_folder = status_cfg.folder or client.control_mailbox
+    with client.session(target_folder, readonly=False) as mailbox:
+        _delete_existing(client, status_cfg.subject)
         message = EmailMessage()
-        message["Subject"] = STATUS_SUBJECT
+        message["Subject"] = status_cfg.subject
         message["From"] = "mailai@local"
         message["To"] = "mailai@local"
         message.set_content(payload.decode("utf-8"))
-        client.client.append(client.control_mailbox, message.as_bytes())
+        client.client.append(mailbox, message.as_bytes())
 
 
-def _delete_existing(client: MailAIImapClient) -> None:
-    uids = client.client.search(["SUBJECT", STATUS_SUBJECT])
+def _delete_existing(client: MailAIImapClient, subject: str) -> None:
+    uids = client.client.search(["SUBJECT", subject])
     if not uids:
         return
     client.client.delete_messages(uids)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,19 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_DIR = PROJECT_ROOT / "mailai" / "src"
 if SRC_DIR.exists():
     sys.path.insert(0, str(SRC_DIR))
+
+import pytest
+
+from mailai.config.loader import reset_runtime_config
+
+CONFIG_PATH = Path(__file__).resolve().parent / "data" / "config.cfg"
+
+
+@pytest.fixture(autouse=True)
+def runtime_config(monkeypatch):
+    monkeypatch.setenv("MAILAI_CONFIG_PATH", str(CONFIG_PATH))
+    reset_runtime_config()
+    try:
+        yield
+    finally:
+        reset_runtime_config()

--- a/tests/e2e/test_config_flow.py
+++ b/tests/e2e/test_config_flow.py
@@ -1,0 +1,84 @@
+import io
+from email.message import EmailMessage
+
+import pytest
+
+pytest_plugins = ["tests.unit.conftest"]
+
+from mailai.config import yamlshim
+from mailai.config.loader import get_runtime_config
+from mailai.config.backup import EncryptedRulesBackup
+from mailai.config.status_store import StatusStore
+from mailai.config.schema import RulesV2
+from mailai.core.engine import load_active_rules
+from mailai.utils.logging import JsonLogger
+
+
+@pytest.fixture
+def config_context(tmp_path, imap_client):
+    client, backend = imap_client
+    backup = EncryptedRulesBackup(tmp_path / "rules.bak", b"1" * 32)
+    status = StatusStore(tmp_path / "status.yaml")
+    logger = JsonLogger(stream=io.StringIO(), component="test")
+    return client, backend, backup, status, logger
+
+
+def _append_yaml(client, text: str) -> None:
+    message = EmailMessage()
+    message["Subject"] = get_runtime_config().mail.rules.subject
+    message["From"] = "user@example.com"
+    message["To"] = "mailai@local"
+    message.set_content(text)
+    with client.control_session(readonly=False) as mailbox:
+        client.client.append(mailbox, message.as_bytes())
+
+
+def test_cycle_normal_updates_status(config_context):
+    client, backend, backup, status, logger = config_context
+    rules = load_active_rules(client=client, status=status, backup=backup, logger=logger, run_id="cycle")
+    stored = status.load()
+    assert stored.config_ref is not None
+    assert stored.config_ref.uid in backend.mailboxes[client.control_mailbox]
+    assert stored.config_checksum == stored.config_ref.checksum
+    assert rules.version == 2
+
+
+def test_user_edit_detected_and_backed_up(config_context):
+    client, backend, backup, status, logger = config_context
+    load_active_rules(client=client, status=status, backup=backup, logger=logger, run_id="bootstrap")
+    first_uid = status.load().config_ref.uid
+    with client.control_session(readonly=False) as mailbox:
+        client.client.delete_messages([first_uid])
+        client.client.expunge()
+    edited = RulesV2.minimal()
+    edited.meta.description = "Edited"
+    yaml = yamlshim.dump(edited.model_dump(mode="json"))
+    _append_yaml(client, yaml)
+    second = load_active_rules(client=client, status=status, backup=backup, logger=logger, run_id="edit")
+    stored = status.load()
+    assert stored.config_ref.uid != first_uid
+    assert stored.config_checksum == stored.config_ref.checksum
+    assert second.meta.description == "Edited"
+
+
+def test_corruption_falls_back_to_backup(config_context):
+    client, backend, backup, status, logger = config_context
+    load_active_rules(client=client, status=status, backup=backup, logger=logger, run_id="first")
+    _append_yaml(client, "not: [yaml")
+    rules = load_active_rules(client=client, status=status, backup=backup, logger=logger, run_id="corrupt")
+    stored = status.load()
+    assert any(event.type == "config_invalid" for event in stored.events)
+    assert stored.restored_rules_from_backup is True
+    assert rules.version == 2
+
+
+def test_oversize_mail_triggers_restoration(config_context):
+    client, backend, backup, status, logger = config_context
+    load_active_rules(client=client, status=status, backup=backup, logger=logger, run_id="first")
+    hard_limit = get_runtime_config().mail.rules.limits.hard_limit
+    _append_yaml(client, "x" * (hard_limit + 5))
+    rules = load_active_rules(client=client, status=status, backup=backup, logger=logger, run_id="oversize")
+    stored = status.load()
+    assert stored.events[-1].type == "config_restored"
+    assert stored.events[-1].details == "oversize"
+    assert rules.version == 2

--- a/tests/unit/fakes.py
+++ b/tests/unit/fakes.py
@@ -1,20 +1,51 @@
-"""Test doubles for IMAP interactions."""
 from __future__ import annotations
 
-import email
-from typing import Dict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email import policy
+from email.message import EmailMessage
+from email.parser import BytesParser
+from email.utils import format_datetime, make_msgid
+from typing import Dict, Iterable
+
+from mailai.config.loader import get_runtime_config
+
+
+@dataclass
+class _MessageRecord:
+    uid: int
+    mailbox: str
+    subject: str
+    message_id: str
+    internaldate: datetime
+    message_bytes: bytes
+    body_text: str
+    charset: str
+
+    @property
+    def header_bytes(self) -> bytes:
+        message = BytesParser(policy=policy.default).parsebytes(self.message_bytes)
+        headers = []
+        for name, value in message.items():
+            headers.append(f"{name}: {value}\r\n".encode("utf-8"))
+        headers.append(b"\r\n")
+        return b"".join(headers)
 
 
 class FakeImapBackend:
     """In-memory IMAP backend implementing a subset of `imapclient.IMAPClient`."""
 
     def __init__(self) -> None:
-        self.mailboxes: Dict[str, Dict[int, Dict[str, object]]] = {
-            "INBOX": {},
-            "MailIA": {},
-            "MailIA/Quarantine": {},
+        settings = get_runtime_config()
+        default_mailbox = settings.imap.default_mailbox
+        control = settings.imap.control_namespace
+        quarantine = f"{control}/{settings.imap.quarantine_subfolder}".replace("//", "/")
+        self.mailboxes: Dict[str, Dict[int, _MessageRecord]] = {
+            default_mailbox: {},
+            control: {},
+            quarantine: {},
         }
-        self.selected = "INBOX"
+        self.selected = default_mailbox
         self.uid_counter = 1
 
     # Session management -------------------------------------------------
@@ -37,30 +68,64 @@ class FakeImapBackend:
 
     # Message operations -------------------------------------------------
     def search(self, criteria):
+        if not criteria:
+            return []
+        if criteria[0] != "SUBJECT":
+            return []
         subject = criteria[1]
-        return [uid for uid, msg in self.mailboxes[self.selected].items() if msg["subject"] == subject]
+        return [uid for uid, msg in self.mailboxes[self.selected].items() if msg.subject == subject]
 
-    def fetch(self, uids, parts):
-        data = {}
+    def fetch(self, uids: Iterable[int], parts: Iterable[bytes | str]):
+        response: Dict[int, Dict[bytes, object]] = {}
+        requested = [part.encode() if isinstance(part, str) else part for part in parts]
         for uid in uids:
-            payload = self.mailboxes[self.selected][uid]["payload"]
-            data[uid] = {b"RFC822": payload}
-        return data
+            if uid not in self.mailboxes[self.selected]:
+                continue
+            record = self.mailboxes[self.selected][uid]
+            payload: Dict[bytes, object] = {}
+            for part in requested:
+                upper = part.upper()
+                if upper in {b"RFC822", b"BODY[]"}:
+                    payload[part] = record.message_bytes
+                elif upper in {b"BODY[TEXT]", b"BODY.PEEK[TEXT]"}:
+                    payload[part] = record.body_text.encode(record.charset)
+                elif upper in {b"BODY[HEADER]", b"BODY.PEEK[HEADER]"}:
+                    payload[part] = record.header_bytes
+                elif upper == b"RFC822.SIZE":
+                    payload[part] = len(record.body_text.encode(record.charset))
+                elif upper == b"INTERNALDATE":
+                    payload[part] = format_datetime(record.internaldate).encode("utf-8")
+            response[uid] = payload
+        return response
 
     def append(self, mailbox: str, message_bytes: bytes) -> None:
         self.create_folder(mailbox)
-        message = email.message_from_bytes(message_bytes)
-        payload = message.get_payload(decode=True)
-        if payload is None:
-            payload = message.get_payload().encode()
-        self.mailboxes[mailbox][self.uid_counter] = {
-            "subject": message["Subject"],
-            "payload": payload,
-        }
+        parser = BytesParser(policy=policy.default)
+        message = parser.parsebytes(message_bytes)
+        if not isinstance(message, EmailMessage):
+            message = EmailMessage(policy=policy.default)
+            message.set_content(message_bytes.decode("utf-8"))
+        body = message.get_body(preferencelist=("plain",))
+        charset = body.get_content_charset("utf-8") if body else "utf-8"
+        text = body.get_content() if body else message.get_content()
+        message_id = message["Message-ID"] or make_msgid(domain="fake.local")
+        if body is None:
+            charset = message.get_content_charset("utf-8")
+        record = _MessageRecord(
+            uid=self.uid_counter,
+            mailbox=mailbox,
+            subject=str(message["Subject"]),
+            message_id=str(message_id),
+            internaldate=datetime.now(timezone.utc),
+            message_bytes=message_bytes,
+            body_text=str(text),
+            charset=str(charset),
+        )
+        self.mailboxes[mailbox][self.uid_counter] = record
         self.uid_counter += 1
 
-    def delete_messages(self, uids) -> None:
-        for uid in uids:
+    def delete_messages(self, uids: Iterable[int]) -> None:
+        for uid in list(uids):
             self.mailboxes[self.selected].pop(uid, None)
 
     def expunge(self) -> None:  # pragma: no cover - trivial
@@ -73,7 +138,7 @@ class FakeImapBackend:
 
     def copy(self, uid: int, destination: str) -> None:
         self.create_folder(destination)
-        self.mailboxes[destination][uid] = dict(self.mailboxes[self.selected][uid])
+        self.mailboxes[destination][uid] = self.mailboxes[self.selected][uid]
 
     def add_gmail_labels(self, uid, labels) -> None:  # pragma: no cover - unused in tests
         return None

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1,20 +1,122 @@
+import json
 import pathlib
 
 import pytest
 
-from mailai.config import loader
-from mailai.config.schema import RulesV2
+from mailai.config.loader import (
+    ConfigLoadError,
+    RuntimeConfigError,
+    get_runtime_config,
+    load_runtime_config,
+    parse_and_validate,
+    reset_runtime_config,
+)
 
 
-def test_load_rules(tmp_path: pathlib.Path):
-    data = pathlib.Path("examples/rules.yaml").read_bytes()
-    document = loader.load_rules(data)
-    assert isinstance(document.model, RulesV2)
-    assert document.model.version == 2
-    dumped = loader.dump_rules(document.model)
-    assert dumped.startswith(b"version: 2")
+def test_parse_and_validate_roundtrip():
+    text = pathlib.Path("examples/rules.yaml").read_text()
+    model = parse_and_validate(text)
+    assert model.version == 2
+    assert model.rules
 
 
-def test_invalid_rules_raises():
-    with pytest.raises(loader.YamlValidationError):
-        loader.load_rules(b"version: 1")
+def test_invalid_rules_raise_config_load_error():
+    with pytest.raises(ConfigLoadError):
+        parse_and_validate("version: 1")
+
+
+def test_load_runtime_config_from_yaml(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.cfg"
+    config_path.write_text(
+        """
+version: 1
+paths:
+  state_dir: /var/lib/mailai
+  config_dir: /etc/mailai
+  models_dir: /var/lib/mailai/models
+imap:
+  default_mailbox: Primary
+  control_namespace: Drafts
+  quarantine_subfolder: Quarantine
+mail:
+  rules:
+    subject: "MailAI: custom rules"
+    folder: Drafts
+    limits:
+      soft_limit: 1024
+      hard_limit: 2048
+  status:
+    subject: "MailAI: status.yaml"
+    folder: Drafts
+    limits:
+      soft_limit: 1024
+      hard_limit: 2048
+llm:
+  model_path: /models/llm.gguf
+  threads: 4
+  ctx_size: 1024
+  sentinel_path: /state/llm.json
+  max_age: 3600
+feedback:
+  enabled: true
+  mailbox: Drafts/Feedback
+  subject_prefix: "Feedback:"
+"""
+    )
+    monkeypatch.setenv("MAILAI_CONFIG_PATH", str(config_path))
+    reset_runtime_config()
+    runtime = get_runtime_config()
+    assert runtime.mail.rules.subject == "MailAI: custom rules"
+    assert runtime.imap.default_mailbox == "Primary"
+    assert runtime.llm.model_path == "/models/llm.gguf"
+
+
+def test_load_runtime_config_from_json(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    payload = {
+        "version": 1,
+        "paths": {
+            "state_dir": "/var/lib/mailai",
+            "config_dir": "/etc/mailai",
+            "models_dir": "/var/lib/mailai/models",
+        },
+        "imap": {
+            "default_mailbox": "Inbox",
+            "control_namespace": "Drafts",
+            "quarantine_subfolder": "Quarantine",
+        },
+        "mail": {
+            "rules": {
+                "subject": "MailAI: rules.yaml",
+                "folder": "Drafts",
+                "limits": {"soft_limit": 10, "hard_limit": 20},
+            },
+            "status": {
+                "subject": "MailAI: status.yaml",
+                "folder": "Drafts",
+                "limits": {"soft_limit": 10, "hard_limit": 20},
+            },
+        },
+        "llm": {
+            "model_path": "/models/model.gguf",
+            "threads": 2,
+            "ctx_size": 512,
+            "sentinel_path": "/state/sentinel.json",
+            "max_age": 7200,
+        },
+        "feedback": {"enabled": False, "mailbox": None, "subject_prefix": None},
+    }
+    config_path.write_text(json.dumps(payload))
+    monkeypatch.setenv("MAILAI_CONFIG_PATH", str(config_path))
+    reset_runtime_config()
+    runtime = load_runtime_config()
+    assert runtime.llm.threads == 2
+    assert runtime.mail.rules.limits.hard_limit == 20
+
+
+def test_missing_config_raises(tmp_path, monkeypatch):
+    missing = tmp_path / "nope.cfg"
+    monkeypatch.setenv("MAILAI_CONFIG_PATH", str(missing))
+    reset_runtime_config()
+    with pytest.raises(RuntimeConfigError):
+        load_runtime_config()

--- a/tests/unit/test_config_watcher.py
+++ b/tests/unit/test_config_watcher.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timezone
+
+from mailai.config.schema import ConfigReference
+from mailai.config.watcher import change_reason, has_changed
+from mailai.imap.rules_mail import RulesMailRef
+
+
+def _ref(uid: int, checksum: str) -> ConfigReference:
+    return ConfigReference(uid=uid, message_id="m", internaldate=datetime.now(timezone.utc).isoformat(), checksum=checksum)
+
+
+def _mail(uid: int, checksum: str) -> RulesMailRef:
+    return RulesMailRef(
+        uid=uid,
+        message_id="m",
+        internaldate=datetime.now(timezone.utc),
+        charset="utf-8",
+        body_text="version: 2\n",
+        checksum=checksum,
+    )
+
+
+def test_has_changed_detects_uid_difference():
+    prev = _ref(1, "sha256:aaa")
+    latest = _mail(2, "sha256:aaa")
+    assert has_changed(prev, latest) is True
+    assert change_reason(prev, latest) == "uid change"
+
+
+def test_has_changed_detects_checksum_difference():
+    prev = _ref(1, "sha256:aaa")
+    latest = _mail(1, "sha256:bbb")
+    assert has_changed(prev, latest) is True
+    assert change_reason(prev, latest) == "checksum change"

--- a/tests/unit/test_engine_config.py
+++ b/tests/unit/test_engine_config.py
@@ -1,0 +1,64 @@
+import io
+from email.message import EmailMessage
+
+import pytest
+
+from mailai.config.backup import EncryptedRulesBackup
+from mailai.config.loader import get_runtime_config
+from mailai.config.status_store import StatusStore
+from mailai.core.engine import load_active_rules
+from mailai.utils.logging import JsonLogger
+
+
+@pytest.fixture
+def config_env(tmp_path, imap_client):
+    client, backend = imap_client
+    backup = EncryptedRulesBackup(tmp_path / "rules.bak", b"0" * 32)
+    status = StatusStore(tmp_path / "status.yaml")
+    logger = JsonLogger(stream=io.StringIO(), component="test")
+    return client, backend, backup, status, logger
+
+
+def _append_raw(client, text: str) -> None:
+    message = EmailMessage()
+    message["Subject"] = get_runtime_config().mail.rules.subject
+    message["From"] = "user@example.com"
+    message["To"] = "mailai@local"
+    message.set_content(text)
+    with client.control_session(readonly=False) as mailbox:
+        client.client.append(mailbox, message.as_bytes())
+
+
+def test_absent_config_triggers_restoration(config_env):
+    client, backend, backup, status, logger = config_env
+    rules = load_active_rules(client=client, status=status, backup=backup, logger=logger, run_id="r1")
+    assert rules.version == 2
+    stored = status.load()
+    assert stored.events[-1].type == "config_restored"
+    assert stored.restored_rules_from_backup is False
+    assert backup.has_backup() is True
+
+
+def test_invalid_yaml_falls_back_to_backup(config_env):
+    client, backend, backup, status, logger = config_env
+    load_active_rules(client=client, status=status, backup=backup, logger=logger, run_id="init")
+    _append_raw(client, "not: [valid")
+    rules = load_active_rules(client=client, status=status, backup=backup, logger=logger, run_id="run2")
+    stored = status.load()
+    assert any(event.type == "config_invalid" for event in stored.events)
+    assert any(event.type == "config_restored" for event in stored.events)
+    assert stored.restored_rules_from_backup is True
+    assert rules.version == 2
+
+
+def test_oversize_mail_is_replaced(config_env):
+    client, backend, backup, status, logger = config_env
+    load_active_rules(client=client, status=status, backup=backup, logger=logger, run_id="init")
+    hard_limit = get_runtime_config().mail.rules.limits.hard_limit
+    _append_raw(client, "a" * (hard_limit + 1))
+    rules = load_active_rules(client=client, status=status, backup=backup, logger=logger, run_id="run3")
+    stored = status.load()
+    assert stored.events[-1].type == "config_restored"
+    assert stored.events[-1].details == "oversize"
+    assert stored.summary.errors >= 1
+    assert rules.version == 2

--- a/tests/unit/test_rules_mail.py
+++ b/tests/unit/test_rules_mail.py
@@ -1,38 +1,22 @@
-import pytest
+from datetime import datetime, timezone
 
-from mailai.config.loader import load_rules
-from mailai.config.schema import RulesV2
-from mailai.imap.rules_mail import RULES_SUBJECT, read_rules, upsert_rules
+from mailai.config.loader import get_runtime_config, parse_and_validate
+from mailai.imap.rules_mail import append_minimal_template, find_latest
 
 
-def test_read_rules_bootstraps_minimal(imap_client):
+def test_find_latest_returns_none_when_missing(imap_client):
+    client, _ = imap_client
+    assert find_latest(client=client) is None
+
+
+def test_append_minimal_template_creates_message(imap_client):
     client, backend = imap_client
-    document = read_rules(client)
-    assert isinstance(document.model, RulesV2)
-    assert document.model.meta.description == "Default MailAI policy"
-    assert RULES_SUBJECT in [msg["subject"] for msg in backend.mailboxes[client.control_mailbox].values()]
-
-
-def test_read_rules_repairs_corruption(imap_client):
-    client, backend = imap_client
-    document = read_rules(client)
-    assert document.model.version == 2
-    # Corrupt the primary rules message while keeping the backup intact.
-    mailbox = backend.mailboxes[client.control_mailbox]
-    for uid, entry in mailbox.items():
-        if entry["subject"] == RULES_SUBJECT:
-            entry["payload"] = b"not: yaml"
-            break
-    restored = read_rules(client)
-    assert restored.model.version == 2
-    payloads = [entry["payload"] for entry in backend.mailboxes[client.control_mailbox].values()]
-    assert all(payload != b"not: yaml" for payload in payloads)
-
-
-def test_upsert_rules_enforces_limits(imap_client):
-    client, backend = imap_client
-    model = RulesV2.minimal()
-    upsert_rules(client, model)
-    stored = next(entry["payload"] for entry in backend.mailboxes[client.control_mailbox].values() if entry["subject"] == RULES_SUBJECT)
-    reloaded = load_rules(stored)
-    assert reloaded.model.meta.description == "Default MailAI policy"
+    ref = append_minimal_template(client=client)
+    assert ref is not None
+    assert ref.uid in backend.mailboxes[client.control_mailbox]
+    assert ref.message_id is not None
+    assert ref.internaldate <= datetime.now(timezone.utc)
+    parsed = parse_and_validate(ref.body_text)
+    assert parsed.version == 2
+    subject = get_runtime_config().mail.rules.subject
+    assert any(entry.subject == subject for entry in backend.mailboxes[client.control_mailbox].values())


### PR DESCRIPTION
## Summary
- add a runtime configuration loader that validates config.cfg (YAML or JSON) and exposes the settings via RuntimeConfig
- feed IMAP helpers, engine safeguards, and the LLM health probe from the runtime config while updating fakes and tests to use the new entry points
- document the central configuration file and ship an example config for operators

## Testing
- python -m compileall mailai/src
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68df64552ef08331ad41d731a45ac10f