### PR TITLE
Add configurable LLM timeout settings

### DIFF
--- a/examples/config.cfg
+++ b/examples/config.cfg
@@ -26,6 +26,9 @@ llm:
   ctx_size: 2048
   sentinel_path: /var/lib/mailai/.cache/llm_ready.json
   max_age: 86400
+  load_timeout_s: 120
+  warmup_completion_timeout_s: 45
+  healthcheck_timeout_s: 20
 feedback:
   enabled: false
   mailbox: Drafts/Feedback

--- a/mailai/README.md
+++ b/mailai/README.md
@@ -49,7 +49,16 @@ loader accepts either YAML or JSON and validates the payload against the
 [`RuntimeConfig`](mailai/src/mailai/config/schema.py) schema. Typical settings
 include IMAP defaults (control namespace, quarantine folder, configuration
 subjects), size limits for the control mails, filesystem paths for state and
-models, local LLM parameters, and optional feedback mailboxes.
+models, local LLM parameters, and optional feedback mailboxes. The `llm`
+section supports timeouts that control start-up and health probes:
+
+- `load_timeout_s` – wall-clock allowance for loading the GGUF weights before
+  the runtime reports a failure (defaults to 60 seconds).
+- `warmup_completion_timeout_s` – time budget for issuing the synthetic
+  completion used during warm-up to ensure the bindings work (defaults to 30
+  seconds).
+- `healthcheck_timeout_s` – per-request timeout for periodic liveness checks
+  after the runtime is serving traffic (defaults to 10 seconds).
 
 When running inside Docker place `config.cfg` under `/etc/mailai/`. Native
 deployments search the current working directory first and fall back to

--- a/mailai/src/mailai/config/schema.py
+++ b/mailai/src/mailai/config/schema.py
@@ -96,6 +96,9 @@ class RuntimeLLMConfig(BaseModel):
     ctx_size: int = Field(gt=0)
     sentinel_path: str
     max_age: int = Field(gt=0)
+    load_timeout_s: int = Field(default=60, gt=0)
+    warmup_completion_timeout_s: int = Field(default=30, gt=0)
+    healthcheck_timeout_s: int = Field(default=10, gt=0)
 
 
 class RuntimeConfig(BaseModel):

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -57,6 +57,9 @@ llm:
   ctx_size: 1024
   sentinel_path: /state/llm.json
   max_age: 3600
+  load_timeout_s: 180
+  warmup_completion_timeout_s: 60
+  healthcheck_timeout_s: 15
 feedback:
   enabled: true
   mailbox: Drafts/Feedback
@@ -69,6 +72,9 @@ feedback:
     assert runtime.mail.rules.subject == "MailAI: custom rules"
     assert runtime.imap.default_mailbox == "Primary"
     assert runtime.llm.model_path == "/models/llm.gguf"
+    assert runtime.llm.load_timeout_s == 180
+    assert runtime.llm.warmup_completion_timeout_s == 60
+    assert runtime.llm.healthcheck_timeout_s == 15
 
 
 def test_load_runtime_config_from_json(tmp_path, monkeypatch):
@@ -103,6 +109,9 @@ def test_load_runtime_config_from_json(tmp_path, monkeypatch):
             "ctx_size": 512,
             "sentinel_path": "/state/sentinel.json",
             "max_age": 7200,
+            "load_timeout_s": 75,
+            "warmup_completion_timeout_s": 25,
+            "healthcheck_timeout_s": 8,
         },
         "feedback": {"enabled": False, "mailbox": None, "subject_prefix": None},
     }
@@ -112,6 +121,9 @@ def test_load_runtime_config_from_json(tmp_path, monkeypatch):
     runtime = load_runtime_config()
     assert runtime.llm.threads == 2
     assert runtime.mail.rules.limits.hard_limit == 20
+    assert runtime.llm.load_timeout_s == 75
+    assert runtime.llm.warmup_completion_timeout_s == 25
+    assert runtime.llm.healthcheck_timeout_s == 8
 
 
 def test_missing_config_raises(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add load, warm-up, and healthcheck timeout fields to the runtime LLM schema with defaults
- document the new timeouts in the sample config and README runtime configuration guide
- update configuration loader tests to cover the new options in YAML and JSON inputs

## Testing
- python -m compileall mailai/src
- pytest tests/unit/test_config_loader.py

------
https://chatgpt.com/codex/tasks/task_b_68df72db93a483319388010206e2dbb6