### PR TITLE
Improve LLM warmup timeout handling

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -65,66 +65,230 @@ warmup_llm() {
         fail "LLM warmup failed"
     fi
 PY
-import os
-from pathlib import Path
 import json
+import os
+import signal
 import stat
 import time
-import signal
+from pathlib import Path
 
 from llama_cpp import Llama
 
-model_path = os.environ.get("LLM_MODEL_PATH")
-if not model_path:
-    raise SystemExit("LLM_MODEL_PATH is not set")
-model_file = Path(model_path)
-if not model_file.is_file():
-    raise SystemExit(f"model file not found: {model_file}")
+from mailai.config.loader import RuntimeConfigError, get_runtime_config
 
-threads = int(os.environ.get("LLM_N_THREADS", "3") or 3)
-ctx_size = int(os.environ.get("LLM_CTX_SIZE", "2048") or 2048)
 
-llm = Llama(
-    model_path=str(model_file),
-    n_ctx=ctx_size,
-    n_threads=threads,
-    logits_all=False,
-    embedding=False,
-    verbose=False,
-)
-try:
-    signal.signal(signal.SIGALRM, lambda _signum, _frame: (_ for _ in ()).throw(TimeoutError("completion timeout")))
-    signal.alarm(5)
-    result = llm(
-        "ok?",
-        max_tokens=4,
-        temperature=0.0,
-        top_p=1.0,
-        repeat_penalty=1.0,
-        return_dict=True,
+def _int_from_env(name, default):
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer, got {value!r}") from exc
+
+
+class _TimeoutAlarm:
+    def __init__(self, seconds, message):
+        self._seconds = int(seconds)
+        self._message = message
+        self._previous = None
+
+    def __enter__(self):
+        if self._seconds <= 0:
+            return self
+
+        def _handle(_signum, _frame):
+            raise TimeoutError(self._message)
+
+        self._previous = signal.getsignal(signal.SIGALRM)
+        signal.signal(signal.SIGALRM, _handle)
+        signal.alarm(self._seconds)
+        return self
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        signal.alarm(0)
+        if self._previous is not None:
+            signal.signal(signal.SIGALRM, self._previous)
+        return False
+
+
+def _load_settings():
+    try:
+        runtime = get_runtime_config()
+    except RuntimeConfigError as exc:
+        raise SystemExit(f"unable to load runtime config: {exc}") from exc
+
+    llm_cfg = runtime.llm
+    model_path = os.environ.get("LLM_MODEL_PATH", llm_cfg.model_path)
+    if not model_path:
+        raise SystemExit("LLM_MODEL_PATH is not set")
+    model_file = Path(model_path)
+    if not model_file.is_file():
+        raise SystemExit(f"model file not found: {model_file}")
+
+    threads = _int_from_env("LLM_N_THREADS", llm_cfg.threads)
+    ctx_size = _int_from_env("LLM_CTX_SIZE", llm_cfg.ctx_size)
+    sentinel_path = Path(os.environ.get("LLM_HEALTH_SENTINEL", llm_cfg.sentinel_path))
+    load_timeout_s = _int_from_env("LLM_LOAD_TIMEOUT_S", llm_cfg.load_timeout_s)
+    completion_timeout_s = _int_from_env(
+        "LLM_WARMUP_COMPLETION_TIMEOUT_S", llm_cfg.warmup_completion_timeout_s
     )
-finally:
-    signal.alarm(0)
-    del llm
+    healthcheck_timeout_s = _int_from_env(
+        "LLM_HEALTHCHECK_TIMEOUT_S", llm_cfg.healthcheck_timeout_s
+    )
 
-choices = result.get("choices") if isinstance(result, dict) else None
-if not choices:
-    raise SystemExit("warmup returned no choices")
+    return {
+        "model_file": model_file,
+        "threads": threads,
+        "ctx_size": ctx_size,
+        "sentinel_path": sentinel_path,
+        "load_timeout_s": load_timeout_s,
+        "completion_timeout_s": completion_timeout_s,
+        "healthcheck_timeout_s": healthcheck_timeout_s,
+    }
 
-first_choice = choices[0]
-text = first_choice.get("text") if isinstance(first_choice, dict) else None
+def _run_warmup(settings):
+    attempts = 3
+    backoff = 1.0
+    last_error = None
 
-sentinel_path = Path(os.environ.get("LLM_HEALTH_SENTINEL", "/var/lib/mailai/.cache/llm_ready.json"))
-sentinel_path.parent.mkdir(parents=True, exist_ok=True)
-payload = {
-    "model_path": str(model_file),
-    "threads": threads,
-    "ctx_size": ctx_size,
-    "completed_at": time.time(),
-    "response": text,
-}
-sentinel_path.write_text(json.dumps(payload, ensure_ascii=False))
-sentinel_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    for attempt in range(1, attempts + 1):
+        try:
+            model_file = settings["model_file"]
+            threads = settings["threads"]
+            ctx_size = settings["ctx_size"]
+            load_timeout_s = settings["load_timeout_s"]
+            completion_timeout_s = settings["completion_timeout_s"]
+
+            llm = None
+            result = None
+            load_started = time.monotonic()
+            with _TimeoutAlarm(load_timeout_s, f"LLM load timed out after {load_timeout_s}s"):
+                llm = Llama(
+                    model_path=str(model_file),
+                    n_ctx=ctx_size,
+                    n_threads=threads,
+                    logits_all=False,
+                    embedding=False,
+                    verbose=False,
+                )
+            load_duration = time.monotonic() - load_started
+
+            try:
+                completion_started = time.monotonic()
+                with _TimeoutAlarm(
+                    completion_timeout_s,
+                    f"LLM warmup completion timed out after {completion_timeout_s}s",
+                ):
+                    result = llm(
+                        "ok?",
+                        max_tokens=4,
+                        temperature=0.0,
+                        top_p=1.0,
+                        repeat_penalty=1.0,
+                        return_dict=True,
+                    )
+                completion_duration = time.monotonic() - completion_started
+            finally:
+                if llm is not None:
+                    del llm
+
+            choices = result.get("choices") if isinstance(result, dict) else None
+            if not choices:
+                raise RuntimeError("warmup returned no choices")
+
+            first_choice = choices[0]
+            text = first_choice.get("text") if isinstance(first_choice, dict) else None
+
+            print(
+                json.dumps(
+                    {
+                        "event": "llm_warmup_attempt",
+                        "attempt": attempt,
+                        "status": "success",
+                        "load_duration_s": load_duration,
+                        "completion_duration_s": completion_duration,
+                    }
+                ),
+                flush=True,
+            )
+
+            return {
+                **settings,
+                "response": text,
+                "attempt": attempt,
+                "load_duration_s": load_duration,
+                "completion_duration_s": completion_duration,
+            }
+        except TimeoutError as exc:
+            last_error = ("timeout", str(exc))
+            print(
+                json.dumps(
+                    {
+                        "event": "llm_warmup_attempt",
+                        "attempt": attempt,
+                        "status": "timeout",
+                        "error": str(exc),
+                    }
+                ),
+                flush=True,
+            )
+        except Exception as exc:  # pragma: no cover - defensive guard
+            last_error = ("error", str(exc))
+            print(
+                json.dumps(
+                    {
+                        "event": "llm_warmup_attempt",
+                        "attempt": attempt,
+                        "status": "error",
+                        "error": str(exc),
+                    }
+                ),
+                flush=True,
+            )
+
+        if attempt < attempts:
+            time.sleep(backoff)
+            backoff = min(backoff * 2, 4.0)
+
+    if last_error is None:
+        raise SystemExit("LLM warmup failed")
+    reason, message = last_error
+    if reason == "timeout":
+        raise SystemExit(message)
+    raise SystemExit(f"LLM warmup failed after {attempts} attempts: {message}")
+
+
+def main():
+    settings = _load_settings()
+    result = _run_warmup(settings)
+
+    sentinel_path = result["sentinel_path"]
+    if not isinstance(sentinel_path, Path):
+        sentinel_path = Path(str(sentinel_path))
+    sentinel_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "model_path": str(result["model_file"]),
+        "threads": result["threads"],
+        "ctx_size": result["ctx_size"],
+        "completed_at": time.time(),
+        "response": result.get("response"),
+        "load_duration_s": result.get("load_duration_s"),
+        "completion_duration_s": result.get("completion_duration_s"),
+        "healthcheck_timeout_s": result.get("healthcheck_timeout_s"),
+    }
+    sentinel_path.write_text(json.dumps(payload, ensure_ascii=False))
+    sentinel_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive guard
+        raise SystemExit(str(exc)) from exc
 PY
     log "LLM warmup succeeded"
 }

--- a/examples/config.cfg
+++ b/examples/config.cfg
@@ -26,6 +26,9 @@ llm:
   ctx_size: 2048
   sentinel_path: /var/lib/mailai/.cache/llm_ready.json
   max_age: 86400
+  load_timeout_s: 180
+  warmup_completion_timeout_s: 20
+  healthcheck_timeout_s: 15
 feedback:
   enabled: false
   mailbox: Drafts/Feedback

--- a/mailai/src/mailai/config/schema.py
+++ b/mailai/src/mailai/config/schema.py
@@ -96,6 +96,9 @@ class RuntimeLLMConfig(BaseModel):
     ctx_size: int = Field(gt=0)
     sentinel_path: str
     max_age: int = Field(gt=0)
+    load_timeout_s: int = Field(gt=0, default=120)
+    warmup_completion_timeout_s: int = Field(gt=0, default=10)
+    healthcheck_timeout_s: int = Field(gt=0, default=5)
 
 
 class RuntimeConfig(BaseModel):

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -57,6 +57,9 @@ llm:
   ctx_size: 1024
   sentinel_path: /state/llm.json
   max_age: 3600
+  load_timeout_s: 180
+  warmup_completion_timeout_s: 20
+  healthcheck_timeout_s: 15
 feedback:
   enabled: true
   mailbox: Drafts/Feedback
@@ -69,6 +72,7 @@ feedback:
     assert runtime.mail.rules.subject == "MailAI: custom rules"
     assert runtime.imap.default_mailbox == "Primary"
     assert runtime.llm.model_path == "/models/llm.gguf"
+    assert runtime.llm.load_timeout_s == 180
 
 
 def test_load_runtime_config_from_json(tmp_path, monkeypatch):
@@ -103,6 +107,9 @@ def test_load_runtime_config_from_json(tmp_path, monkeypatch):
             "ctx_size": 512,
             "sentinel_path": "/state/sentinel.json",
             "max_age": 7200,
+            "load_timeout_s": 90,
+            "warmup_completion_timeout_s": 12,
+            "healthcheck_timeout_s": 8,
         },
         "feedback": {"enabled": False, "mailbox": None, "subject_prefix": None},
     }
@@ -112,6 +119,7 @@ def test_load_runtime_config_from_json(tmp_path, monkeypatch):
     runtime = load_runtime_config()
     assert runtime.llm.threads == 2
     assert runtime.mail.rules.limits.hard_limit == 20
+    assert runtime.llm.healthcheck_timeout_s == 8
 
 
 def test_missing_config_raises(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- load LLM warmup settings from the runtime configuration with environment overrides and enforce separate load/completion alarms, retries, and structured logging during warmup
- persist load/completion timings and the configured healthcheck timeout in the sentinel payload for downstream health probes
- extend the runtime configuration schema, example config, and unit tests to cover the new timeout parameters

## Testing
- python -m compileall mailai/src
- pytest tests/unit/test_config_loader.py

------
https://chatgpt.com/codex/tasks/task_b_68df775f665883318b50380964b6ce12