### PR TITLE
Document runtime LLM timeouts and extend loader tests

### DIFF
--- a/examples/config.cfg
+++ b/examples/config.cfg
@@ -26,8 +26,14 @@ llm:
   ctx_size: 2048
   sentinel_path: /var/lib/mailai/.cache/llm_ready.json
   max_age: 86400
+  # Maximum number of seconds allowed for the llama.cpp bindings to initialise
+  # the quantised model during warm-up.
   load_timeout_s: 180
+  # Deadline for the warm-up completion request which exercises the model with a
+  # short prompt.
   warmup_completion_timeout_s: 20
+  # Timeout applied to the standalone `mailai-health-llm` probe when verifying
+  # the cached sentinel contents.
   healthcheck_timeout_s: 15
 feedback:
   enabled: false

--- a/mailai/README.md
+++ b/mailai/README.md
@@ -56,6 +56,24 @@ deployments search the current working directory first and fall back to
 `/etc/mailai/config.cfg` and `/var/lib/mailai/config.cfg`. A reference document
 is available under [`examples/config.cfg`](../examples/config.cfg).
 
+### LLM warm-up and healthcheck timeouts
+
+The `llm` section of `config.cfg` controls how the embedded llama.cpp runtime is
+initialised. In addition to the model location and threading parameters, three
+timeouts guard the warm-up and healthcheck sequence:
+
+- `load_timeout_s` (default **120s**) – caps how long the GGUF model may take to
+  load during start-up before MailAI aborts the attempt.
+- `warmup_completion_timeout_s` (default **10s**) – limits the inference window
+  for the warm-up completion that verifies the model can answer a trivial
+  prompt.
+- `healthcheck_timeout_s` (default **5s**) – bounds the execution time for the
+  `mailai-health-llm` probe that revalidates the warm-up sentinel.
+
+Increase these values when running larger models or slower storage where the
+initial load might exceed the defaults. The sample configuration documents
+recommended overrides for Raspberry Pi deployments.
+
 ## IMAP YAML Configuration
 
 MailAI stores its configuration and diagnostics inside the IMAP account under a

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -73,6 +73,8 @@ feedback:
     assert runtime.imap.default_mailbox == "Primary"
     assert runtime.llm.model_path == "/models/llm.gguf"
     assert runtime.llm.load_timeout_s == 180
+    assert runtime.llm.warmup_completion_timeout_s == 20
+    assert runtime.llm.healthcheck_timeout_s == 15
 
 
 def test_load_runtime_config_from_json(tmp_path, monkeypatch):
@@ -119,6 +121,8 @@ def test_load_runtime_config_from_json(tmp_path, monkeypatch):
     runtime = load_runtime_config()
     assert runtime.llm.threads == 2
     assert runtime.mail.rules.limits.hard_limit == 20
+    assert runtime.llm.load_timeout_s == 90
+    assert runtime.llm.warmup_completion_timeout_s == 12
     assert runtime.llm.healthcheck_timeout_s == 8
 
 


### PR DESCRIPTION
## Summary
- document the LLM load, warm-up, and healthcheck timeouts in the sample `config.cfg`
- expand the runtime configuration guide with explanations and defaults for the new timeout settings
- extend the configuration loader tests to assert the timeout fields in both YAML and JSON inputs

## Testing
- python -m compileall mailai/src
- pytest tests/unit/test_config_loader.py

------
https://chatgpt.com/codex/tasks/task_b_68df7a4c7708833181186a5262abf78d