### PR TITLE
Enforce YAML-only runtime configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 .venv/
 venv/
 data/
+!tests/data/
+!tests/data/config.yaml
 config/secrets/
 config/*.yml
 !.gitkeep

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ identifiers and bounded scores (0..3) covering:
 - `suspicion_flags` – closed vocabulary including `link_mismatch`,
   `attachment_push`, and other high-signal heuristics.
 
-The optional enrichment pipeline is enabled through the new
-`intent_features` section in `config.cfg` (see `examples/config.yaml`). Messages
+The optional enrichment pipeline is enabled through the
+`intent_features` section in `config.yaml` (see `examples/intent_features.yaml`). Messages
 exceeding the configured `scam_singularity_quarantine` threshold are isolated in
 the quarantine mailbox without ever persisting plaintext content.
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,4 +1,38 @@
-# Intent feature enrichment configuration snippet.
+version: 1
+paths:
+  state_dir: /var/lib/mailai
+  config_dir: /etc/mailai
+  models_dir: /var/lib/mailai/models
+imap:
+  default_mailbox: INBOX
+  control_namespace: Drafts
+  quarantine_subfolder: Quarantine
+mail:
+  rules:
+    subject: "MailAI: rules.yaml"
+    folder: Drafts
+    limits:
+      soft_limit: 65536
+      hard_limit: 131072
+  status:
+    subject: "MailAI: status.yaml"
+    folder: Drafts
+    limits:
+      soft_limit: 65536
+      hard_limit: 131072
+llm:
+  model_path: /var/lib/mailai/models/qwen2.5-3b-instruct-q4_0.gguf
+  threads: 3
+  ctx_size: 2048
+  sentinel_path: /var/lib/mailai/.cache/llm_ready.json
+  max_age: 86400
+  load_timeout_s: 180
+  warmup_completion_timeout_s: 20
+  healthcheck_timeout_s: 15
+feedback:
+  enabled: false
+  mailbox: Drafts/Feedback
+  subject_prefix: "MailAI Feedback"
 intent_features:
   enabled: true
   llm:

--- a/examples/intent_features.yaml
+++ b/examples/intent_features.yaml
@@ -1,0 +1,10 @@
+# Intent feature enrichment configuration snippet.
+intent_features:
+  enabled: true
+  llm:
+    max_tokens: 64
+    temperature: 0.0
+    timeout_s: 3
+  thresholds:
+    scam_singularity_quarantine: 2
+    urgency_warn: 3

--- a/mailai/README.md
+++ b/mailai/README.md
@@ -46,8 +46,8 @@ and never persists cleartext email data.
 
 ## Global runtime configuration
 
-MailAI centralises all runtime tunables inside a single `config.cfg` file. The
-loader accepts either YAML or JSON and validates the payload against the
+MailAI centralises all runtime tunables inside a single `config.yaml` file. The
+loader accepts strict YAML and validates the payload against the
 [`RuntimeConfig`](mailai/src/mailai/config/schema.py) schema. Typical settings
 include IMAP defaults (control namespace, quarantine folder, configuration
 subjects), size limits for the control mails, filesystem paths for state and
@@ -55,14 +55,14 @@ models, local LLM parameters, optional feedback mailboxes, and the
 `intent_features` block controlling token budgets, temperature, timeouts, and
 quarantine thresholds for the enrichment pipeline.
 
-When running inside Docker place `config.cfg` under `/etc/mailai/`. Native
+When running inside Docker place `config.yaml` under `/etc/mailai/`. Native
 deployments search the current working directory first and fall back to
-`/etc/mailai/config.cfg` and `/var/lib/mailai/config.cfg`. A reference document
-is available under [`examples/config.cfg`](../examples/config.cfg).
+`/etc/mailai/config.yaml` and `/var/lib/mailai/config.yaml`. A reference document
+is available under [`examples/config.yaml`](../examples/config.yaml).
 
 ### LLM warm-up and healthcheck timeouts
 
-The `llm` section of `config.cfg` controls how the embedded llama.cpp runtime is
+The `llm` section of `config.yaml` controls how the embedded llama.cpp runtime is
 initialised. In addition to the model location and threading parameters, three
 timeouts guard the warm-up and healthcheck sequence:
 
@@ -96,7 +96,7 @@ mailbox that contains two human-readable messages:
   metrics, privacy checks, and a `proposals` section where learner-generated
   rules are rendered as YAML diffs with an explanation.
 
-Both messages inherit their soft and hard size limits from `config.cfg`. MailAI
+Both messages inherit their soft and hard size limits from `config.yaml`. MailAI
 attempts to keep the payload below the soft ceiling by truncating verbose
 sections such as `notes` and `proposals` while preserving the most relevant
 entries. Example documents are provided under

--- a/mailai/src/mailai/config/__init__.py
+++ b/mailai/src/mailai/config/__init__.py
@@ -21,14 +21,14 @@ Interfaces:
     in-memory models.
   - load_status / dump_status: Manage the ``status.yaml`` runtime document.
   - get_runtime_config / load_runtime_config / reset_runtime_config: Resolve
-    ``config.cfg`` and expose a cached runtime configuration object.
+    ``config.yaml`` and expose a cached runtime configuration object.
   - RulesV2 / RuntimeConfig / StatusV2 / ValidationError: Pydantic models and
     error type used by the higher-level services.
 
 Invariants:
   - Only the documented helpers are reachable through the package namespace.
   - Callers must go through the schema types to ensure strict validation before
-    touching user-provided YAML/JSON payloads.
+    touching user-provided YAML payloads.
 
 Safety/Performance:
   - Explicit exports minimise import cost on constrained Raspberry Pi systems

--- a/mailai/src/mailai/config/schema.py
+++ b/mailai/src/mailai/config/schema.py
@@ -1,7 +1,7 @@
 """Strict configuration schemas for MailAI runtime documents.
 
 What:
-  Define the strongly typed models representing ``config.cfg``, ``rules.yaml``,
+  Define the strongly typed models representing ``config.yaml``, ``rules.yaml``,
   and ``status.yaml`` along with helper validators.
 
 Why:
@@ -339,7 +339,7 @@ class IntentFeaturesConfig(BaseModel):
 
 
 class RuntimeConfig(BaseModel):
-    """Top-level runtime configuration derived from ``config.cfg``.
+    """Top-level runtime configuration derived from ``config.yaml``.
 
     What:
       Aggregate IMAP, filesystem, LLM, and feedback settings consumed by the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ import pytest
 
 from mailai.config.loader import reset_runtime_config
 
-CONFIG_PATH = Path(__file__).resolve().parent / "data" / "config.cfg"
+CONFIG_PATH = Path(__file__).resolve().parent / "data" / "config.yaml"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/data/config.yaml
+++ b/tests/data/config.yaml
@@ -26,16 +26,19 @@ llm:
   ctx_size: 2048
   sentinel_path: /var/lib/mailai/.cache/llm_ready.json
   max_age: 86400
-  # Maximum number of seconds allowed for the llama.cpp bindings to initialise
-  # the quantised model during warm-up.
   load_timeout_s: 180
-  # Deadline for the warm-up completion request which exercises the model with a
-  # short prompt.
   warmup_completion_timeout_s: 20
-  # Timeout applied to the standalone `mailai-health-llm` probe when verifying
-  # the cached sentinel contents.
   healthcheck_timeout_s: 15
 feedback:
   enabled: false
   mailbox: Drafts/Feedback
   subject_prefix: "MailAI Feedback"
+intent_features:
+  enabled: true
+  llm:
+    max_tokens: 64
+    temperature: 0.0
+    timeout_s: 3
+  thresholds:
+    scam_singularity_quarantine: 2
+    urgency_warn: 3


### PR DESCRIPTION
## Summary
- update the configuration loader to treat `config.yaml` as the canonical runtime file and remove the JSON code path
- refresh documentation, examples, and fixtures to reference the YAML filename and provide a shared test fixture
- update unit tests to target YAML-only loading semantics and drop the JSON round-trip case

## Testing
- python -m compileall mailai/src
- pytest tests/unit/test_config_loader.py tests/e2e/test_config_flow.py

------
https://chatgpt.com/codex/tasks/task_b_68dfce71b7908331b9a0ba1290008d6e