### PR TITLE
Handle scalar speech act payloads correctly

### DIFF
--- a/mailai/src/mailai/core/features/intent_extract.py
+++ b/mailai/src/mailai/core/features/intent_extract.py
@@ -274,8 +274,12 @@ def _merge_llm_payload(target: Dict[str, object], payload: Dict[str, object]) ->
     for key in ("speech_acts", "persuasion", "suspicion_flags"):
         if key in payload:
             values = payload[key]
-            if isinstance(values, Iterable):
+            if isinstance(values, str):
+                target[key].append(values)
+            elif isinstance(values, Iterable):
                 target[key].extend(str(value) for value in values)
+            else:
+                target[key].append(str(values))
     for key in ("urgency_score", "insistence_score", "commercial_pressure", "scam_singularity"):
         if key in payload:
             candidate = int(payload[key])

--- a/tests/unit/test_intent_features.py
+++ b/tests/unit/test_intent_features.py
@@ -18,7 +18,7 @@ How:
 
 import pytest
 
-from mailai.core.features.intent_extract import infer_intent_and_tone
+from mailai.core.features.intent_extract import _merge_llm_payload, infer_intent_and_tone
 from mailai.core.features.schema import IntentLLMSettings, ParsedMailMeta, TextStats, UrlInfo
 from mailai.utils.privacy import PrivacyViolation, assert_bounded_scores, assert_closed_vocab
 
@@ -59,3 +59,23 @@ def test_link_mismatch_flag() -> None:
     urls = UrlInfo(target_domains=("phish.test",))
     result = infer_intent_and_tone(meta, stats, urls)
     assert "link_mismatch" in result["suspicion_flags"]
+
+
+def test_merge_llm_payload_scalar_speech_act() -> None:
+    """What/Why/How: scalar speech-act tokens must remain intact during merge."""
+
+    target = {
+        "intent": "unknown",
+        "speech_acts": ["inform"],
+        "persuasion": [],
+        "suspicion_flags": [],
+        "urgency_score": 0,
+        "insistence_score": 0,
+        "commercial_pressure": 0,
+        "scam_singularity": 0,
+    }
+    payload = {"speech_acts": "request"}
+
+    _merge_llm_payload(target, payload)
+
+    assert target["speech_acts"] == ["inform", "request"]


### PR DESCRIPTION
## Summary
- treat scalar speech-act payloads from the LLM as single vocabulary tokens during merge
- add a regression test guarding against character-wise splitting when combining payloads

## Testing
- python -m compileall mailai/src
- pytest tests/unit/test_intent_features.py

------
https://chatgpt.com/codex/tasks/task_b_68dfd158ce888331830f63b898db36c2