### PR TITLE
Update README runtime warmup timeout details

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ model via `LLM_MODEL_PATH` and override other variables as needed:
   secrets, and fails fast when directories are missing or misconfigured.
 - A warmup routine loads the GGUF model via `llama-cpp-python`, performs a tiny
   completion (`"ok?"` with four tokens), and aborts the container if it cannot
-  complete within five seconds.
+  complete within the configurable timeout (default ten seconds via
+  `warmup_completion_timeout_s`).
 - The healthcheck reuses the in-process integration and fails whenever the model
   cannot be loaded or respond, ensuring orchestrators detect LLM regressions.
 - The root filesystem is kept read-only at runtime; only `/var/lib/mailai`


### PR DESCRIPTION
## Summary
- clarify the warm-up completion timeout description in the runtime guarantees section
- note that the timeout defaults to ten seconds and is configurable via `warmup_completion_timeout_s`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dfd2f0b9688331a390d410d87e93a8